### PR TITLE
Automatically integrate the packed VS debug engine extension

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,13 +33,13 @@ jobs:
           repository: albertziegenhagel/childdebugger-concord
           tag: head
           fileName: childdebugger-concord-x86_64-windows.zip
-          out-file-path: concord-extension
+          out-file-path: vsdbg-engine-extension
           extract: true
 
       - name: Package
         run: |
-          rm concord-extension/childdebugger-concord-x86_64-windows.zip
-          rm -r concord-extension/tests
+          rm vsdbg-engine-extension/childdebugger-concord-x86_64-windows.zip
+          rm -r vsdbg-engine-extension/tests
           vsce package --target win32-x64 --pre-release
           mv childdebugger-win32-x64-*.vsix childdebugger-win32-x64.vsix
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+vsdbg-engine-extension/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,24 +1,15 @@
-# Ignore extension configs
-.vscode/**
 
-# Ignore test files
-.vscode-test/**
-out/**
+**
 
-# Ignore source code
-src/**
+!package.json
 
-# Ignore node modules
-node_modules/**
+!LICENSE.*
+!README.*
+!CHANGELOG.*
 
-# Ignore Misc
-.github/**
-.yarnrc
-vsc-extension-quickstart.md
-**/.gitignore
-**/tsconfig.json
-**/tsconfig.node.json
-**/webpack.config.js
-**/.eslintrc.json
-**/*.map
-**/*.ts
+!dist/*.js
+
+!vsdbg-engine-extension/bin/*.dll
+!vsdbg-engine-extension/bin/*.pdb
+!vsdbg-engine-extension/bin/*.vsdconfig
+!vsdbg-engine-extension/info.txt

--- a/README.md
+++ b/README.md
@@ -1,43 +1,71 @@
-# Child Debugger - VS Code extension
+# Child Process Debugger for VS Code
 
-Prototype code for a VS Code extension to support (Windows) child process debugging in VS Code.
+A VS Code extension to support (Windows) child process debugging in Visual Studio Code via the `cppvsdbg` Debug Adapter. If installed, it will automatically attach a debugger to all child processes spawned by any process that is currently being debugged.
 
-This extension is supposed to work in combination with the "Concord" VS Debug Engine extension to be found at https://github.com/albertziegenhagel/childdebugger-concord
+It is intended to be the VS Code equivalent of the [Microsoft Child Process Debugging Power Tool](https://marketplace.visualstudio.com/items?itemName=vsdbgplat.MicrosoftChildProcessDebuggingPowerTool2022).
 
-## Getting Started
+## Features
 
-> NOTE: pre-build binaries are currently only available for Windows x86-64.
+- Automatically attaches to child processes of any native application currently being debugged.
+- Supports the `cppvsdbg` Debug Adapter on Windows provided by [`ms-vscode.cpptools`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+- Detects child process creation by the Win32 API functions [`CreateProcessA`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa), [`CreateProcessW`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw), [`CreateProcessAsUserA`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessasusera) and [`CreateProcessAsUserW`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessasuserw).
+- Suspends the child process while we are waiting for the debugger to attach, so that:
+  - it is guaranteed that you can debug the child process right from the first user instruction.
+  - even very short lived child processes can be debugged (especially useful for "proxy" processes that just launch another child process).
+- Suspends the parent process while we are waiting for the debugger to attach, so that:
+  - it does not proceed and generates some unexpected behavior (e.g. a parent process that original creates a suspended child process could resume it before we had a change to attach the debugger).
+- Recursively attaches to child processes of child processes.
+- Filtering of processes to attach to by the executable name or the command line they are invoked with.
 
-1. Download the pre-build package of this VS Code extension from
+## Installation
 
-   https://github.com/albertziegenhagel/childdebugger-vscode/releases/download/head/childdebugger-win32-x64.vsix
+> NOTE: pre-build binaries are currently available for Windows x86-64 only.
 
-   and install it in VS Code (see https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix).
+This extension has not yet been published in the VS Code Marketplace.
 
+You can download the latest pre-release `*.vsix` package from the "Rolling release" at
 
-2. Download the latest pre-build binary package of the "Concord" VS Debug Engine from
+https://github.com/albertziegenhagel/childdebugger-vscode/releases/tag/head
 
-   https://github.com/albertziegenhagel/childdebugger-concord/releases/download/head/childdebugger-concord-x86_64-windows.zip
+and [install it in VS Code manually](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix).
 
-   and extract the archive to an arbitrary directory (in the following assumed to be `C:\dev\childdebugger-concord\`).
+The extension will automatically install an integration into the VS Debug Engine when it is activated. You can confirm that this integration was installed successfully by checking that you see something similar to 
 
-   Create a file `$HOME\.cppvsdbg\extensions\ChildDebugger.link`, which's only content is a single line with the path to the `bin` subfolder of the directory we just extracted. E.g.:
+```
+-------------------------------------------------------------------
+You may only use the C/C++ Extension for Visual Studio Code
+with Visual Studio Code, Visual Studio or Visual Studio for Mac
+software to help you develop and test your applications.
+-------------------------------------------------------------------
+Loading extensions from 'C:\Users\[User]\.vscode\extensions\albertziegenhagel-childdebugger-X.X.X\vsdbg-engine-extension\bin'.
+```
 
-   ```
-   C:\dev\childdebugger-concord\bin
-   ```
+in the beginning of the `DEBUG CONSOLE` output view when debugging any native application through the C++ `cppvsdbg` debugger.
 
-3. Start debugging any native program through the C++ `cppvsdbg` debugger. You should now see something similar to 
+## Dependencies
 
-   ```
-   -------------------------------------------------------------------
-   You may only use the C/C++ Extension for Visual Studio Code
-   with Visual Studio Code, Visual Studio or Visual Studio for Mac
-   software to help you develop and test your applications.
-   -------------------------------------------------------------------
-   Loading extensions from 'C:\dev\childdebugger-concord\bin'.
-   ```
+- [`ms-vscode.cpptools`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) >= 1.4.0.
 
-   in the beginning of the `DEBUG CONSOLE` output view.
+## Implementation Details
 
-   If the program starts any child process via the Win32 API functions [`CreateProcessA`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa) or [`CreateProcessW`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw), VS Code should automatically attach to the child process.
+This extension works by integrating a [VS Debug Engine extension](https://github.com/microsoft/ConcordExtensibilitySamples) that can be found [here](https://github.com/albertziegenhagel/childdebugger-concord).
+
+While a process is being debugged it will:
+
+  - Automatically establish internal breakpoints on calls to the Win32 API functions [`CreateProcessA`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa), [`CreateProcessW`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw), [`CreateProcessAsUserA`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessasusera) and [`CreateProcessAsUserW`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessasuserw) when `kernel32.dll` or `advapi32.dll` are loaded into the process.
+  - When such a breakpoint is hit, it will:
+    - Read the `lpApplicationName` and `lpCommandLine` arguments passed to the function call and filter based on the settings whether we want to attach to the new child process or not. If we do not want to attach, we stop here.
+    - Read the `dwCreationFlags` and see whether [`CREATE_SUSPENDED`](learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#:~:text=CREATE_SUSPENDED) is set. If it is not set, we will overwrite the internal process memory and set it to make sure that the child will be created in suspended state (can be disabled in the settings).
+    - Determine the return instruction address of the function call and add a new internal breakpoint there.
+  - When the breakpoint at the function return address is hit, it will:
+    - Read the return value of the function call and abort if the create process call failed.
+    - Read the resulting `lpProcessInformation` structure to determine the process ID and main thread ID of the new child process.
+    - Suspend the parent process (can be disabled in the settings).
+    - Send a message to VS Code that it should attach to the new child process.
+  - When VS Code receives that message, it will start a new debug session to attach to the child process.
+  - When VS Code finished attaching to the new child process, it will:
+    - Send a message to the newly created debug session for the child process so that it can:
+      - Resume the child process if it was suspended by the extension.
+      - Inform it that it should skip over the ["initial breakpoint"](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/initial-breakpoint) for this process (can be disabled in the settings).
+    - Send a message to the parents debug session so that it can:
+      - Resume the parent process if it was suspended by the extension.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Albert Ziegenhagel",
   "publisher": "albertziegenhagel",
   "license": "MIT",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "homepage": "https://github.com/albertziegenhagel/childdebugger-vscode",
   "bugs": {
     "url": "https://github.com/albertziegenhagel/childdebugger-vscode/issues"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
             "default": true,
             "description": "Whether to skip stopping on the \"initial breakpoint\" during the process initialization of the new child process."
           },
-          "childDebugger.filter.processes": {
+          "childDebugger.filter.childProcesses": {
             "order": 4,
             "type": "array",
             "items": {
@@ -74,11 +74,11 @@
             },
             "description": "Allows to filter which processes to attach to."
           },
-          "childDebugger.filter.attachOthers": {
+          "childDebugger.filter.attachOtherChildren": {
             "order": 5,
             "type": "boolean",
             "default": true,
-            "description": "Whether to attach to any process launches that did not match any of the explicit filters."
+            "description": "Whether to attach to any processes that did not match any of the explicit child process filters."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "categories": [
     "Other"
   ],
+  "extensionDependencies": [
+    "ms-vscode.cpptools"
+  ],
   "activationEvents": [
     "onDebug"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "childdebugger",
   "displayName": "Child Process Debugger",
-  "description": "Auto-attach debugger to child processes",
+  "description": "Auto-attach debugger to child processes for cppvsdbg",
   "author": "Albert Ziegenhagel",
   "publisher": "albertziegenhagel",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
+    "test": "node ./out/test/runTest.js",
+    "vscode:uninstall": "node ./dist/uninstall.js"
   },
   "devDependencies": {
     "@types/glob": "^8.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
+import { installVsDbgEngineExtensionIntegration } from './integration';
 
-var outputChannel = vscode.window.createOutputChannel("ChildDebugger");
+const outputChannelName = "Child Debugger";
+
+var outputChannel = vscode.window.createOutputChannel(outputChannelName);
 
 interface EngineProcessConfig {
 	applicationName: string|undefined,
@@ -37,6 +40,16 @@ enum CustomMessageType {
 const childDebuggerSourceId = "{0BB89D05-9EAD-4295-9A74-A241583DE420}";
 
 export function activate(context: vscode.ExtensionContext) {
+
+	if(context.extensionMode === vscode.ExtensionMode.Production) {
+		installVsDbgEngineExtensionIntegration(context.extensionPath).catch().then((value) => {
+			outputChannel.appendLine("Successfully installed VS Debug Engine integration.");
+		}, (reason) => {
+			vscode.window.showErrorMessage(`Failed to install VS Debug Engine integration.\nSee "${outputChannelName}" output channel for more information.`);
+			outputChannel.appendLine("Failed to install VS Debug Engine integration:");
+			outputChannel.appendLine(`  ${reason}`);
+		});
+	}
 
 	vscode.debug.registerDebugAdapterTrackerFactory('*', {
 		createDebugAdapterTracker(session: vscode.DebugSession) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 
 		var processConfigs : EngineProcessConfig[] = [];
-		for (const entry of configuration.get<any[]>("filter.processes", [])) {
+		for (const entry of configuration.get<any[]>("filter.childProcesses", [])) {
 			processConfigs.push({
 				applicationName : entry['applicationName'],
 				commandLine : entry['commandLine'],
@@ -178,7 +178,7 @@ export function activate(context: vscode.ExtensionContext) {
 			skipInitialBreakpoint: configuration.get<boolean>("general.skipInitialBreakpoint", true),
 
 			processConfigs: processConfigs,
-			attachOthers: configuration.get<boolean>("filter.attachOthers", true),
+			attachOthers: configuration.get<boolean>("filter.attachOtherChildren", true),
 		};
 
 		// Send the settings to the debug engine extension in the new session.

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -2,19 +2,12 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 
-async function getLinkFilePath()
+function getLinkFilePath()
 {
-    const packageJsonPath = path.resolve(path.dirname(__filename), '..', 'package.json');
+    const publisher     = "albertziegenhagel";
+    const extensionName = "childdebugger";
 
-    // TODO: add proper error handling!
-
-    const packageJsonContentString = await fs.promises.readFile(packageJsonPath, 'utf8');
-
-    const packageJsonContent = JSON.parse(packageJsonContentString);
-
-    const version = packageJsonContent.version;
-
-    const linkFileName = `albertziegenhagel-childdebugger-${version}.link`;
+    const linkFileName = `${publisher}-${extensionName}.link`;
 
     return path.resolve(os.homedir(), '.cppvsdbg', 'extensions', linkFileName);
 }
@@ -23,7 +16,7 @@ export async function installVsDbgEngineExtensionIntegration(extensionPath : str
 {
     const vsDbgExtensionPath = path.resolve(extensionPath, 'vsdbg-engine-extension', 'bin');
 
-    const linkFilePath = await getLinkFilePath();
+    const linkFilePath = getLinkFilePath();
 
     await fs.promises.mkdir(path.dirname(linkFilePath), {recursive: true});
 
@@ -35,8 +28,8 @@ export async function installVsDbgEngineExtensionIntegration(extensionPath : str
 
 export function uninstallVsDbgEngineExtensionIntegration()
 {
-    // Simply ignore the errors. We can't do anything about them anyways?
-    getLinkFilePath().then((linkFilePath) => {
-        fs.unlink(linkFilePath, (err) => {});
-    });
+    const linkFilePath = getLinkFilePath();
+
+    // Simply ignore the error. We can't do anything about it anyways?
+    fs.unlink(linkFilePath, (err) => {});
 }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,0 +1,42 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+async function getLinkFilePath()
+{
+    const packageJsonPath = path.resolve(path.dirname(__filename), '..', 'package.json');
+
+    // TODO: add proper error handling!
+
+    const packageJsonContentString = await fs.promises.readFile(packageJsonPath, 'utf8');
+
+    const packageJsonContent = JSON.parse(packageJsonContentString);
+
+    const version = packageJsonContent.version;
+
+    const linkFileName = `albertziegenhagel-childdebugger-${version}.link`;
+
+    return path.resolve(os.homedir(), '.cppvsdbg', 'extensions', linkFileName);
+}
+
+export async function installVsDbgEngineExtensionIntegration(extensionPath : string)
+{
+    const vsDbgExtensionPath = path.resolve(extensionPath, 'vsdbg-engine-extension', 'bin');
+
+    const linkFilePath = await getLinkFilePath();
+
+    await fs.promises.mkdir(path.dirname(linkFilePath), {recursive: true});
+
+    // TODO: Instead of always overwriting the file, we might want to check whether it exists first?
+    //       And if it exists, should we check that it's contents is correct? What if it is not?
+    //       Do we want to overwrite it or keep the current contents? Should we at least emit a warning?
+    await fs.promises.writeFile(linkFilePath, vsDbgExtensionPath, { encoding: 'utf8', flag: 'w' });
+}
+
+export function uninstallVsDbgEngineExtensionIntegration()
+{
+    // Simply ignore the errors. We can't do anything about them anyways?
+    getLinkFilePath().then((linkFilePath) => {
+        fs.unlink(linkFilePath, (err) => {});
+    });
+}

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -1,0 +1,4 @@
+
+import { uninstallVsDbgEngineExtensionIntegration } from "./integration";
+
+uninstallVsDbgEngineExtensionIntegration();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,4 +54,41 @@ const extensionConfig = {
     level: "log", // enables logging required for problem matchers
   },
 };
-module.exports = [ extensionConfig ];
+
+/** @type WebpackConfig */
+const uninstallConfig = {
+  target: 'node',
+	mode: 'none',
+
+  entry: './src/uninstall.ts',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'uninstall.js',
+    libraryTarget: 'commonjs2'
+  },
+  externals: {
+    vscode: 'commonjs vscode'
+  },
+  resolve: {
+    extensions: ['.ts']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'ts-loader'
+          }
+        ]
+      }
+    ]
+  },
+  devtool: 'nosources-source-map',
+  infrastructureLogging: {
+    level: "log",
+  },
+};
+
+module.exports = [ extensionConfig, uninstallConfig ];


### PR DESCRIPTION
Adds support that this extension automatically integrates the packed binaries into the vsdbg engine extension. This is accomplished by simply creating/overwriting the required link file in `$HOME/.cppvsdbg/extensions` every time this extension is loaded.
Doing it every time when the extension is loaded, should make sure the link file is always up-to-date (especially when the extension is updated from one version to another). Additionally an uninstall hook was added to make sure the link file will be removed when the VS code extension is uninstalled.

Some other changes included in this PR are:
  - Significant updates to the readme
  - Add `cpptools` as a dependency of this extension
  - Rename some configuration options to make them better suited for potential future changes
  - Reorganize some internal files to control how this extension is packed
  - Increment the version to `0.1.0`