### PR TITLE
Formatting and Static Code Analysis for C++ Code

### DIFF
--- a/.github/workflows/cpp-format.yml
+++ b/.github/workflows/cpp-format.yml
@@ -1,0 +1,22 @@
+name: C++ format
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  
+jobs:
+  job:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run clang-format
+      uses: DoozyX/clang-format-lint-action@v0.17
+      with:
+        source: './vsdbg-engine-extension/src ./vsdbg-engine-extension/tests'
+        exclude: './vsdbg-engine-extension/src/nlohmann'
+        extensions: 'cpp,h'
+        clangFormatVersion: 17

--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -1,0 +1,69 @@
+name: C++ lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  job:
+    name: lint
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: NuGet/setup-nuget@v1
+
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.25.0"
+          ninjaVersion: "^1.11.1"
+  
+      - uses: TheMrMilchmann/setup-msvc-dev@v2
+        with:
+          arch: x64
+  
+      - name: Install VSDbg Engine Extension Dependencies
+        run: |
+          nuget install Microsoft.VSSDK.Debugger.VSDebugEng -Version 17.0.2012801
+          nuget install Microsoft.VSSDK.Debugger.VSDConfigTool -Version 17.0.2012801
+  
+      - name: Configure VSDbg Engine Extension
+        run: |
+          mkdir "build"
+          cd "build"
+          cmake "..\vsdbg-engine-extension" `
+          -G Ninja `
+          -DCMAKE_BUILD_TYPE=Debug `
+          -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+  
+      - name: Generate files
+        run: |
+          cd "build"
+          ninja include\ChildDebugger.contract.h
+  
+      - uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo-root: 'vsdbg-engine-extension'
+          style: 'file'
+          tidy-checks: ''
+          ignore-tidy: '*.h' # Headers are not present in the compile_commands.json file
+          version: 18
+          ignore-format: 'src/nlohmann'
+          database: '../build'
+          extensions: 'cpp,h'
+          files-changed-only: falses
+          thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
+
+      - name: Check for failure
+        if: steps.linter.outputs.checks-failed > 0
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 vsdbg-engine-extension/bin/
+build/

--- a/vsdbg-engine-extension/.clang-format
+++ b/vsdbg-engine-extension/.clang-format
@@ -1,0 +1,162 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  true
+  AlignCompound:   false
+  PadOperators:    true
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: true
+  BeforeWhile:     true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: AfterColon
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+QualifierAlignment: Left
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+PackConstructorInitializers: Never
+FixNamespaceComments: true
+IncludeBlocks:   Preserve
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentExternBlock: NoIndent
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+IntegerLiteralSeparator:
+  Binary: 4
+  Decimal: 0
+  Hex: 4
+InsertBraces:    false
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+...

--- a/vsdbg-engine-extension/.clang-tidy
+++ b/vsdbg-engine-extension/.clang-tidy
@@ -1,0 +1,60 @@
+---
+Checks: >
+  -*,
+  readability-*,
+  readability-identifier-naming,
+  -readability-braces-around-statements,
+  -readability-magic-numbers,
+  -readability-identifier-length,
+  -readability-function-cognitive-complexity,
+  performance-*,
+  -performance-avoid-endl,
+  -performance-enum-size,
+  portability-*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-exception-escape,
+  -bugprone-suspicious-include,
+  misc-*,
+  -misc-non-private-member-variables-in-classes,
+  -misc-include-cleaner,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  concurrency-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-type-union-access,
+FormatStyle: file
+HeaderFilterRegex: ^.*\\src\\.*\.h$
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: lower_case
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.TypeAliasCase
+    value: lower_case
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ConstantCase
+    value: lower_case
+  - key: readability-identifier-naming.TypeTemplateParameterCase
+    value: CamelCase

--- a/vsdbg-engine-extension/.gitignore
+++ b/vsdbg-engine-extension/.gitignore
@@ -1,1 +1,1 @@
-.vscode/
+bin/

--- a/vsdbg-engine-extension/CMakeLists.txt
+++ b/vsdbg-engine-extension/CMakeLists.txt
@@ -19,7 +19,7 @@ target_compile_features(ChildDebugger
 target_compile_definitions(ChildDebugger
   PRIVATE
     "_USRDLL"
-    # "_AMD64_"
+    "VSDEBUGENG_USE_CPP11_SCOPED_ENUMS"
 )
 
 target_sources(ChildDebugger

--- a/vsdbg-engine-extension/src/ChildDebuggerService.cpp
+++ b/vsdbg-engine-extension/src/ChildDebuggerService.cpp
@@ -26,7 +26,7 @@ using namespace Microsoft::VisualStudio::Debugger;
 // Source ID for breakpoints that we create for child process debugging.
 // This allows this extension to only get notified on breakpoints that it created itself.
 // {0BB89D05-9EAD-4295-9A74-A241583DE420} (same as in vsdconfigxml filter)
-static const GUID sourceId = {
+static const GUID source_id = {
     0x0bb8'9d05, 0x9ead, 0x4295, {0x9a, 0x74, 0xa2, 0x41, 0x58, 0x3d, 0xe4, 0x20}
 };
 
@@ -72,9 +72,9 @@ std::wstring utf16_encode(const std::string& input)
 // Retrieve the path to the module (DLL) that holds this function.
 std::optional<std::filesystem::path> get_current_module_path()
 {
-    HMODULE    current_module        = nullptr;
-    const auto *const moduleFunctionAddress = (LPCWSTR)(&get_current_module_path); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-    if(GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, moduleFunctionAddress, &current_module) == FALSE) return std::nullopt;
+    HMODULE           current_module          = nullptr;
+    const auto* const module_function_address = (LPCWSTR)(&get_current_module_path); // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+    if(GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, module_function_address, &current_module) == FALSE) return std::nullopt;
 
     std::array<WCHAR, MAX_PATH> buffer; // FIXME: handle paths longer than MAX_PATH
 
@@ -87,35 +87,27 @@ std::optional<std::filesystem::path> get_current_module_path()
     return result;
 }
 
-#ifdef CreateProcess
-#    undef CreateProcess
-#endif
-
-#ifdef CreateProcessAsUser
-#    undef CreateProcessAsUser
-#endif
-
 enum class CreateFunctionType
 {
-    CreateProcess,
-    CreateProcessAsUser,
-    CreateProcessWithToken,
-    CreateProcessWithLogon
+    create_process,
+    create_process_as_user,
+    create_process_with_token,
+    create_process_with_logon
 };
 
 enum class CustomMessageType
 {
-    Settings     = 1,
-    ResumeChild  = 2,
-    ResumeParent = 3,
-    InformChild  = 4,
+    settings      = 1,
+    resume_child  = 2,
+    resume_parent = 3,
+    inform_child  = 4,
 };
 
 // Base class for breakpoint information classes.
 template<typename Interface>
 class BaseObject : public Interface
 {
-    volatile LONG m_refCount;
+    volatile LONG ref_count_;
 
 public:
     virtual ~BaseObject() = default;
@@ -129,11 +121,11 @@ public:
 
     ULONG __stdcall AddRef() override
     {
-        return (ULONG)InterlockedIncrement(&m_refCount);
+        return (ULONG)InterlockedIncrement(&ref_count_);
     }
     ULONG __stdcall Release() override
     {
-        auto result = (ULONG)InterlockedDecrement(&m_refCount);
+        auto result = (ULONG)InterlockedDecrement(&ref_count_);
         if(result == 0)
         {
             delete this;
@@ -170,9 +162,9 @@ class __declspec(uuid("{1483C347-BDAD-4626-B33F-D16970542239}")) CreateInInfo :
     CreateFunctionType functionType_;
 
 public:
-    explicit CreateInInfo(bool isUnicode, CreateFunctionType functionType) :
-        isUnicode_(isUnicode),
-        functionType_(functionType)
+    explicit CreateInInfo(bool is_unicode, CreateFunctionType function_type) :
+        isUnicode_(is_unicode),
+        functionType_(function_type)
     {}
 
     CreateInInfo(CreateInInfo&)             = delete;
@@ -187,12 +179,12 @@ public:
         return S_OK;
     }
 
-    [[nodiscard]] bool GetIsUnicode() const
+    [[nodiscard]] bool get_is_unicode() const
     {
         return isUnicode_;
     }
 
-    [[nodiscard]] CreateFunctionType GetFunctionType() const
+    [[nodiscard]] CreateFunctionType get_function_type() const
     {
         return functionType_;
     }
@@ -207,8 +199,8 @@ class __declspec(uuid("{F1AB4299-C3EB-47C5-83B7-813E28B9DA89}")) CreateOutInfo :
     bool   suspended_;
 
 public:
-    explicit CreateOutInfo(UINT64 lpProcessInformation, bool suspended) :
-        lpProcessInformation_(lpProcessInformation),
+    explicit CreateOutInfo(UINT64 process_information, bool suspended) :
+        lpProcessInformation_(process_information),
         suspended_(suspended)
     {}
 
@@ -224,12 +216,12 @@ public:
         return S_OK;
     }
 
-    [[nodiscard]] UINT64 GetProcessInformationAddress() const
+    [[nodiscard]] UINT64 get_process_information_address() const
     {
         return lpProcessInformation_;
     }
 
-    [[nodiscard]] bool GetSuspended() const
+    [[nodiscard]] bool get_suspended() const
     {
         return suspended_;
     }
@@ -255,12 +247,12 @@ public:
         return S_OK;
     }
 
-    [[nodiscard]] bool GetPassedInitialBreakpoint() const
+    [[nodiscard]] bool get_passed_initial_breakpoint() const
     {
         return passedInitialBreakpoint_;
     }
 
-    void SetPassedInitialBreakpoint()
+    void set_passed_initial_breakpoint()
     {
         passedInitialBreakpoint_ = true;
     }
@@ -268,28 +260,31 @@ public:
 
 struct CreateProcessStack
 {
-    UINT64 returnAddress;
+    UINT64 return_address;
 
-    UINT64 lpApplicationName;
-    UINT64 lpCommandLine;
-    UINT64 lpProcessAttributes;
-    UINT64 lpThreadAttributes;
-    UINT8  bInheritHandles;
-    UINT8  Padding1;
-    UINT16 Padding2;
-    UINT32 Padding3;
-    UINT32 dwCreationFlags;
-    UINT32 Padding4;
-    UINT64 lpEnvironment;
-    UINT64 lpCurrentDirectory;
-    UINT64 lpStartupInfo;
-    UINT64 lpProcessInformation;
+    UINT64 lpApplicationName;    // NOLINT(readability-identifier-naming)
+    UINT64 lpCommandLine;        // NOLINT(readability-identifier-naming)
+    UINT64 lpProcessAttributes;  // NOLINT(readability-identifier-naming)
+    UINT64 lpThreadAttributes;   // NOLINT(readability-identifier-naming)
+    UINT8  bInheritHandles;      // NOLINT(readability-identifier-naming)
+    UINT8  Padding1;             // NOLINT(readability-identifier-naming)
+    UINT16 Padding2;             // NOLINT(readability-identifier-naming)
+    UINT32 Padding3;             // NOLINT(readability-identifier-naming)
+    UINT32 dwCreationFlags;      // NOLINT(readability-identifier-naming)
+    UINT32 Padding4;             // NOLINT(readability-identifier-naming)
+    UINT64 lpEnvironment;        // NOLINT(readability-identifier-naming)
+    UINT64 lpCurrentDirectory;   // NOLINT(readability-identifier-naming)
+    UINT64 lpStartupInfo;        // NOLINT(readability-identifier-naming)
+    UINT64 lpProcessInformation; // NOLINT(readability-identifier-naming)
 
-    static DWORD64 getLpApplicationNameFromRegister(const CONTEXT& context)
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static DWORD64 get_lpApplicationName_from_register(const CONTEXT& context)
     {
         return context.Rcx;
     }
-    static DWORD64 getLpCommandLineFromRegister(const CONTEXT& context)
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static DWORD64 get_lpCommandLine_from_register(const CONTEXT& context)
     {
         return context.Rdx;
     }
@@ -297,30 +292,32 @@ struct CreateProcessStack
 
 struct CreateProcessAsUserStack
 {
-    UINT64 returnAddress;
+    UINT64 return_address; // NOLINT(readability-identifier-naming)
 
-    UINT64 hToken;
+    UINT64 hToken; // NOLINT(readability-identifier-naming)
 
-    UINT64 lpApplicationName;
-    UINT64 lpCommandLine;
-    UINT64 lpProcessAttributes;
-    UINT64 lpThreadAttributes;
-    UINT8  bInheritHandles;
-    UINT8  Padding1;
-    UINT16 Padding2;
-    UINT32 Padding3;
-    UINT32 dwCreationFlags;
-    UINT32 Padding4;
-    UINT64 lpEnvironment;
-    UINT64 lpCurrentDirectory;
-    UINT64 lpStartupInfo;
-    UINT64 lpProcessInformation;
+    UINT64 lpApplicationName;    // NOLINT(readability-identifier-naming)
+    UINT64 lpCommandLine;        // NOLINT(readability-identifier-naming)
+    UINT64 lpProcessAttributes;  // NOLINT(readability-identifier-naming)
+    UINT64 lpThreadAttributes;   // NOLINT(readability-identifier-naming)
+    UINT8  bInheritHandles;      // NOLINT(readability-identifier-naming)
+    UINT8  Padding1;             // NOLINT(readability-identifier-naming)
+    UINT16 Padding2;             // NOLINT(readability-identifier-naming)
+    UINT32 Padding3;             // NOLINT(readability-identifier-naming)
+    UINT32 dwCreationFlags;      // NOLINT(readability-identifier-naming)
+    UINT32 Padding4;             // NOLINT(readability-identifier-naming)
+    UINT64 lpEnvironment;        // NOLINT(readability-identifier-naming)
+    UINT64 lpCurrentDirectory;   // NOLINT(readability-identifier-naming)
+    UINT64 lpStartupInfo;        // NOLINT(readability-identifier-naming)
+    UINT64 lpProcessInformation; // NOLINT(readability-identifier-naming)
 
-    static DWORD64 getLpApplicationNameFromRegister(const CONTEXT& context)
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static DWORD64 get_lpApplicationName_from_register(const CONTEXT& context)
     {
         return context.Rdx;
     }
-    static DWORD64 getLpCommandLineFromRegister(const CONTEXT& context)
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static DWORD64 get_lpCommandLine_from_register(const CONTEXT& context)
     {
         return context.R8;
     }
@@ -328,21 +325,21 @@ struct CreateProcessAsUserStack
 
 // TODO: add parameter stack definitions for `CreateProcessWithToken` and `CreateProcessWithLogon`.
 
-HRESULT readMemoryFromStringAt(
+HRESULT read_string_from_memory_at(
     DkmProcess*         process,
     DWORD64             address,
-    bool                isUnicode,
+    bool                is_unicode,
     CComPtr<DkmString>& result)
 {
     if(address == 0) return S_OK;
 
     CAutoDkmArray<BYTE> bytes;
-    if(process->ReadMemoryString(address, DkmReadMemoryFlags::None, isUnicode ? 2 : 1, 0x8000, &bytes) != S_OK)
+    if(process->ReadMemoryString(address, DkmReadMemoryFlags::None, is_unicode ? 2 : 1, 0x8000, &bytes) != S_OK)
     {
         return S_FALSE;
     }
 
-    if(isUnicode)
+    if(is_unicode)
     {
         return DkmString::Create(reinterpret_cast<const wchar_t*>(bytes.Members), &result);
     }
@@ -350,180 +347,180 @@ HRESULT readMemoryFromStringAt(
     return DkmString::Create(CP_ACP, reinterpret_cast<const char*>(bytes.Members), bytes.Length, &result);
 }
 
-bool checkAttachToProcess(
+bool check_attach_to_process(
     const ChildDebuggerSettings& settings,
-    std::ofstream&               logFile,
-    const CComPtr<DkmString>&    applicationName,
-    const CComPtr<DkmString>&    commandLine)
+    std::ofstream&               log_file,
+    const CComPtr<DkmString>&    application_name,
+    const CComPtr<DkmString>&    command_line)
 {
-    if(!applicationName && !commandLine) return settings.attachOthers;
+    if(!application_name && !command_line) return settings.attach_others;
 
-    for(const auto& config : settings.processConfigs)
+    for(const auto& config : settings.process_configs)
     {
-        logFile << "  Check process config: "
-                << "\n";
-        logFile << "    applicationName: " << (config.applicationName ? utf8_encode(*config.applicationName) : "<EMPTY>") << "\n";
-        logFile << "    commandLine: " << (config.commandLine ? utf8_encode(*config.commandLine) : "<EMPTY>") << "\n";
+        log_file << "  Check process config: "
+                 << "\n";
+        log_file << "    applicationName: " << (config.application_name ? utf8_encode(*config.application_name) : "<EMPTY>") << "\n";
+        log_file << "    commandLine: " << (config.command_line ? utf8_encode(*config.command_line) : "<EMPTY>") << "\n";
 
         // Skip invalid, empty config
-        if(!config.applicationName && !config.commandLine) continue;
+        if(!config.application_name && !config.command_line) continue;
 
-        if(config.applicationName)
+        if(config.application_name)
         {
             // We failed to extract the application name: skip
-            if(!applicationName) continue;
+            if(!application_name) continue;
 
             // The current application name is shorter than the config: it can not match, so skip
-            if(applicationName->Length() < config.applicationName->size()) continue;
+            if(application_name->Length() < config.application_name->size()) continue;
 
-            const auto applicationNameView = std::wstring_view(applicationName->Value(), applicationName->Length());
+            const auto application_name_view = std::wstring_view(application_name->Value(), application_name->Length());
 
-            const auto applicationNameFinalPart = applicationNameView.substr(applicationName->Length() - config.applicationName->size(), config.applicationName->size());
+            const auto application_name_final_part = application_name_view.substr(application_name->Length() - config.application_name->size(), config.application_name->size());
 
             // NOTE: we can assume `applicationNameFinalPart.data()` to be null-terminated because it points to the end of the original string.
-            if(DkmString::CompareOrdinalIgnoreCase(applicationNameFinalPart.data(), config.applicationName->c_str()) != 0) continue;
+            if(DkmString::CompareOrdinalIgnoreCase(application_name_final_part.data(), config.application_name->c_str()) != 0) continue;
         }
 
-        if(config.commandLine)
+        if(config.command_line)
         {
             // We failed to extract the command line: skip
-            if(!commandLine) continue;
+            if(!command_line) continue;
 
-            const auto commandLineView = std::wstring_view(commandLine->Value(), commandLine->Length());
+            const auto command_line_view = std::wstring_view(command_line->Value(), command_line->Length());
 
-            if(!commandLineView.contains(*config.commandLine)) continue;
+            if(!command_line_view.contains(*config.command_line)) continue;
         }
 
-        logFile << "    matched. attach: " << config.attach << "\n";
-        logFile.flush();
+        log_file << "    matched. attach: " << config.attach << "\n";
+        log_file.flush();
         return config.attach;
     }
 
-    logFile << "  No process config match. attach: " << settings.attachOthers << "\n";
-    logFile.flush();
-    return settings.attachOthers;
+    log_file << "  No process config match. attach: " << settings.attach_others << "\n";
+    log_file.flush();
+    return settings.attach_others;
 }
 
 template<typename StackType>
-HRESULT handleCallToCreateProcess(
+HRESULT handle_call_to_create_process(
     const ChildDebuggerSettings& settings,
-    std::ofstream&               logFile,
-    DkmThread*                   pThread,
+    std::ofstream&               log_file,
+    DkmThread*                   thread,
     const CONTEXT&               context,
-    bool                         isUnicode)
+    bool                         is_unicode)
 {
     // Extract the application name from the passed arguments.
     // Assuming x64 calling conventions, the pointer to the string in memory is stored in the
     // RCX register for `CreateProcessA` and `CreateProcessW`.
-    CComPtr<DkmString> applicationName;
-    if(readMemoryFromStringAt(pThread->Process(), StackType::getLpApplicationNameFromRegister(context), isUnicode, applicationName) != S_OK)
+    CComPtr<DkmString> application_name;
+    if(read_string_from_memory_at(thread->Process(), StackType::get_lpApplicationName_from_register(context), is_unicode, application_name) != S_OK)
     {
-        logFile << "  FAILED to read application name argument.\n";
-        logFile.flush();
+        log_file << "  FAILED to read application name argument.\n";
+        log_file.flush();
         return S_FALSE;
     }
-    if(applicationName)
+    if(application_name)
     {
-        logFile << "  APP " << utf8_encode(applicationName->Value()) << "\n";
-        logFile.flush();
+        log_file << "  APP " << utf8_encode(application_name->Value()) << "\n";
+        log_file.flush();
     }
 
     // Extract the command line from the passed arguments.
     // Assuming x64 calling conventions, the pointer to the string in memory is stored in the
     // RDX register for `CreateProcessA` and `CreateProcessW`.
-    CComPtr<DkmString> commandLine;
-    if(readMemoryFromStringAt(pThread->Process(), StackType::getLpCommandLineFromRegister(context), isUnicode, commandLine) != S_OK)
+    CComPtr<DkmString> command_line;
+    if(read_string_from_memory_at(thread->Process(), StackType::get_lpCommandLine_from_register(context), is_unicode, command_line) != S_OK)
     {
-        logFile << "  FAILED to read command line argument.\n";
-        logFile.flush();
+        log_file << "  FAILED to read command line argument.\n";
+        log_file.flush();
         return S_FALSE;
     }
-    if(commandLine)
+    if(command_line)
     {
-        logFile << "  CL " << utf8_encode(commandLine->Value()) << "\n";
-        logFile.flush();
+        log_file << "  CL " << utf8_encode(command_line->Value()) << "\n";
+        log_file.flush();
     }
 
-    if(!checkAttachToProcess(settings, logFile, applicationName, commandLine)) return S_OK;
+    if(!check_attach_to_process(settings, log_file, application_name, command_line)) return S_OK;
 
     // The other function arguments are passed on the stack, hence we need to extract it.
     // Assuming x64 calling conventions, the pointer to the stack frame is stored in the
     // RSP register.
     StackType stack;
-    if(pThread->Process()->ReadMemory(context.Rsp, DkmReadMemoryFlags::None, &stack, sizeof(StackType), nullptr) != S_OK)
+    if(thread->Process()->ReadMemory(context.Rsp, DkmReadMemoryFlags::None, &stack, sizeof(StackType), nullptr) != S_OK)
     {
-        logFile << "  FAILED to read stack.\n";
-        logFile.flush();
+        log_file << "  FAILED to read stack.\n";
+        log_file.flush();
         return S_FALSE;
     }
-    logFile << "  dwCreationFlags=" << stack.dwCreationFlags << "\n";
+    log_file << "  dwCreationFlags=" << stack.dwCreationFlags << "\n";
 
     // If want to suspend the child process and it is not already requested to be suspended
     // originally, we enforce a suspended process creation.
-    bool forcedSuspension = false;
+    bool forced_suspension = false;
     if((stack.dwCreationFlags & CREATE_SUSPENDED) != 0)
     {
-        logFile << "  Originally requested suspended start\n";
-        logFile.flush();
+        log_file << "  Originally requested suspended start\n";
+        log_file.flush();
     }
-    else if(settings.suspendChildren)
+    else if(settings.suspend_children)
     {
-        forcedSuspension      = true;
-        const UINT32 newFlags = stack.dwCreationFlags | CREATE_SUSPENDED;
+        forced_suspension      = true;
+        const UINT32 new_flags = stack.dwCreationFlags | CREATE_SUSPENDED;
 
-        CAutoDkmArray<BYTE> newFlagsBytes;
-        DkmAllocArray(sizeof(stack.dwCreationFlags), &newFlagsBytes);
-        memcpy(newFlagsBytes.Members, &newFlags, sizeof(stack.dwCreationFlags));
-        if(pThread->Process()->WriteMemory(context.Rsp + offsetof(StackType, dwCreationFlags), newFlagsBytes) != S_OK)
+        CAutoDkmArray<BYTE> new_flags_bytes;
+        DkmAllocArray(sizeof(stack.dwCreationFlags), &new_flags_bytes);
+        memcpy(new_flags_bytes.Members, &new_flags, sizeof(stack.dwCreationFlags));
+        if(thread->Process()->WriteMemory(context.Rsp + offsetof(StackType, dwCreationFlags), new_flags_bytes) != S_OK)
         {
-            logFile << "  FAILED to force suspended start.\n";
-            logFile.flush();
+            log_file << "  FAILED to force suspended start.\n";
+            log_file.flush();
             return S_FALSE;
         }
-        logFile << "  Force suspended start\n";
-        logFile.flush();
+        log_file << "  Force suspended start\n";
+        log_file.flush();
     }
     else
     {
-        logFile << "  Skip suspended start\n";
-        logFile.flush();
+        log_file << "  Skip suspended start\n";
+        log_file.flush();
     }
 
     // Now, retrieve the return address for this function call.
-    UINT64 returnAddress;
-    UINT64 frameBase;
+    UINT64 return_address;
+    UINT64 frame_base;
     UINT64 vframe;
-    if(pThread->GetCurrentFrameInfo(&returnAddress, &frameBase, &vframe) != S_OK)
+    if(thread->GetCurrentFrameInfo(&return_address, &frame_base, &vframe) != S_OK)
     {
-        logFile << "  FAILED to retrieve function return address.\n";
-        logFile.flush();
+        log_file << "  FAILED to retrieve function return address.\n";
+        log_file.flush();
         return S_FALSE;
     }
 
     CComPtr<DkmInstructionAddress> address;
-    if(pThread->Process()->CreateNativeInstructionAddress(returnAddress, &address) != S_OK)
+    if(thread->Process()->CreateNativeInstructionAddress(return_address, &address) != S_OK)
     {
-        logFile << "  FAILED to create native instruction address from function return address.\n";
-        logFile.flush();
+        log_file << "  FAILED to create native instruction address from function return address.\n";
+        log_file.flush();
         return S_FALSE;
     }
 
     // Create a new breakpoint to be triggered when the child process creation is done.
-    CComPtr<CreateOutInfo> outInfo;
-    outInfo.Attach(new CreateOutInfo(stack.lpProcessInformation, forcedSuspension));
+    CComPtr<CreateOutInfo> out_info;
+    out_info.Attach(new CreateOutInfo(stack.lpProcessInformation, forced_suspension));
 
     CComPtr<Breakpoints::DkmRuntimeInstructionBreakpoint> breakpoint;
-    if(Breakpoints::DkmRuntimeInstructionBreakpoint::Create(sourceId, nullptr, address, false, outInfo, &breakpoint) != S_OK)
+    if(Breakpoints::DkmRuntimeInstructionBreakpoint::Create(source_id, nullptr, address, false, out_info, &breakpoint) != S_OK)
     {
-        logFile << "  FAILED to create breakpoint!\n";
-        logFile.flush();
+        log_file << "  FAILED to create breakpoint!\n";
+        log_file.flush();
         return S_FALSE;
     }
 
     if(breakpoint->Enable() != S_OK)
     {
-        logFile << "  FAILED to enable breakpoint!\n";
-        logFile.flush();
+        log_file << "  FAILED to enable breakpoint!\n";
+        log_file.flush();
         return S_FALSE;
     }
 
@@ -554,14 +551,14 @@ CChildDebuggerService::CChildDebuggerService()
     const auto root = get_current_module_path();
 
     const auto log_file_path = root ? (*root / log_file_name) : log_file_name;
-    logFile.open(log_file_path, std::ios::out | std::ios::app);
+    log_file_.open(log_file_path, std::ios::out | std::ios::app);
 
-    DkmString::Create(L"CreateProcessW", &createProcessFunctionNames[0]);
-    DkmString::Create(L"CreateProcessA", &createProcessFunctionNames[1]);
-    DkmString::Create(L"CreateProcessAsUserW", &createProcessFunctionNames[2]);
-    DkmString::Create(L"CreateProcessAsUserA", &createProcessFunctionNames[3]);
-    DkmString::Create(L"CreateProcessWithTokenW", &createProcessFunctionNames[4]);
-    DkmString::Create(L"CreateProcessWithLogonW", &createProcessFunctionNames[5]);
+    DkmString::Create(L"CreateProcessW", &create_process_function_names_[0]);
+    DkmString::Create(L"CreateProcessA", &create_process_function_names_[1]);
+    DkmString::Create(L"CreateProcessAsUserW", &create_process_function_names_[2]);
+    DkmString::Create(L"CreateProcessAsUserA", &create_process_function_names_[3]);
+    DkmString::Create(L"CreateProcessWithTokenW", &create_process_function_names_[4]);
+    DkmString::Create(L"CreateProcessWithLogonW", &create_process_function_names_[5]);
 }
 
 template<typename T>
@@ -579,147 +576,147 @@ std::optional<std::wstring> try_get_optional_string(const nlohmann::json& json, 
 }
 
 HRESULT STDMETHODCALLTYPE CChildDebuggerService::SendLower(
-    DkmCustomMessage* pCustomMessage,
-    DkmCustomMessage** /*ppReplyMessage*/)
+    DkmCustomMessage* custom_message,
+    DkmCustomMessage** /*reply_message*/)
 {
-    logFile << "On CustomMessage (Debugger PID " << GetCurrentProcessId() << ")\n";
-    logFile << "  MessageCode " << pCustomMessage->MessageCode() << "\n";
-    logFile.flush();
+    log_file_ << "On CustomMessage (Debugger PID " << GetCurrentProcessId() << ")\n";
+    log_file_ << "  MessageCode " << custom_message->MessageCode() << "\n";
+    log_file_.flush();
 
-    switch(CustomMessageType(pCustomMessage->MessageCode()))
+    switch(CustomMessageType(custom_message->MessageCode()))
     {
-    case CustomMessageType::Settings:
+    case CustomMessageType::settings:
     {
-        if(pCustomMessage->Parameter1() == nullptr || pCustomMessage->Parameter1()->Type() != VT_BSTR) return S_FALSE;
+        if(custom_message->Parameter1() == nullptr || custom_message->Parameter1()->Type() != VT_BSTR) return S_FALSE;
 
-        auto* const settingsStr = pCustomMessage->Parameter1()->Value().bstrVal;
+        auto* const settings_str = custom_message->Parameter1()->Value().bstrVal;
 
         // TODO: if we can find a reasonably small JSON parser library that can handle UTF-16 encoded
         // strings, we can probably get rid of this transcoding.
-        const auto utf8SettingsStr = utf8_encode(settingsStr);
+        const auto utf8_settings_str = utf8_encode(settings_str);
 
         try
         {
-            const auto settingsJson = nlohmann::json::parse(utf8SettingsStr);
+            const auto settings_json = nlohmann::json::parse(utf8_settings_str);
 
-            settings.enabled               = try_get_or(settingsJson, "enabled", false);
-            settings.suspendParents        = try_get_or(settingsJson, "suspendParents", true);
-            settings.suspendChildren       = try_get_or(settingsJson, "suspendChildren", true);
-            settings.skipInitialBreakpoint = try_get_or(settingsJson, "skipInitialBreakpoint", true);
-            settings.attachOthers          = try_get_or(settingsJson, "attachOthers", true);
+            settings_.enabled                 = try_get_or(settings_json, "enabled", false);
+            settings_.suspend_parents         = try_get_or(settings_json, "suspendParents", true);
+            settings_.suspend_children        = try_get_or(settings_json, "suspendChildren", true);
+            settings_.skip_initial_breakpoint = try_get_or(settings_json, "skipInitialBreakpoint", true);
+            settings_.attach_others           = try_get_or(settings_json, "attachOthers", true);
 
-            settings.processConfigs.clear();
-            if(settingsJson.count("processConfigs") > 0)
+            settings_.process_configs.clear();
+            if(settings_json.count("processConfigs") > 0)
             {
-                for(const auto& configEntry : settingsJson.at("processConfigs"))
+                for(const auto& config_entry : settings_json.at("processConfigs"))
                 {
-                    settings.processConfigs.push_back(
+                    settings_.process_configs.push_back(
                         ProcessConfig{
-                            .applicationName = try_get_optional_string(configEntry, "applicationName"),
-                            .commandLine     = try_get_optional_string(configEntry, "commandLine"),
-                            .attach          = try_get_or(configEntry, "attach", true)});
+                            .application_name = try_get_optional_string(config_entry, "applicationName"),
+                            .command_line     = try_get_optional_string(config_entry, "commandLine"),
+                            .attach           = try_get_or(config_entry, "attach", true)});
                 }
             }
         }
         catch(const nlohmann::json::parse_error& ex)
         {
-            logFile << "  Failed to parse JSON settings: " << ex.what() << "\n";
-            logFile.flush();
+            log_file_ << "  Failed to parse JSON settings: " << ex.what() << "\n";
+            log_file_.flush();
         }
-        logFile << "  enabled:               " << settings.enabled << "\n";
-        logFile << "  suspendParents:        " << settings.suspendParents << "\n";
-        logFile << "  suspendChildren:       " << settings.suspendChildren << "\n";
-        logFile << "  skipInitialBreakpoint: " << settings.skipInitialBreakpoint << "\n";
-        logFile << "  attachOthers:          " << settings.attachOthers << "\n";
-        logFile << "  processConfigs:\n";
-        for(const auto& config : settings.processConfigs)
+        log_file_ << "  enabled:               " << settings_.enabled << "\n";
+        log_file_ << "  suspendParents:        " << settings_.suspend_parents << "\n";
+        log_file_ << "  suspendChildren:       " << settings_.suspend_children << "\n";
+        log_file_ << "  skipInitialBreakpoint: " << settings_.skip_initial_breakpoint << "\n";
+        log_file_ << "  attachOthers:          " << settings_.attach_others << "\n";
+        log_file_ << "  processConfigs:\n";
+        for(const auto& config : settings_.process_configs)
         {
-            logFile << "    applicationName:        " << (config.applicationName ? utf8_encode(*config.applicationName) : "<EMPTY>") << "\n";
-            logFile << "    commandLine:            " << (config.commandLine ? utf8_encode(*config.commandLine) : "<EMPTY>") << "\n";
-            logFile << "    attach:                 " << config.attach << "\n";
+            log_file_ << "    applicationName:        " << (config.application_name ? utf8_encode(*config.application_name) : "<EMPTY>") << "\n";
+            log_file_ << "    commandLine:            " << (config.command_line ? utf8_encode(*config.command_line) : "<EMPTY>") << "\n";
+            log_file_ << "    attach:                 " << config.attach << "\n";
         }
-        logFile.flush();
+        log_file_.flush();
     }
     break;
-    case CustomMessageType::ResumeChild:
-    case CustomMessageType::InformChild:
+    case CustomMessageType::resume_child:
+    case CustomMessageType::inform_child:
     {
-        if(!settings.enabled) return S_OK;
+        if(!settings_.enabled) return S_OK;
 
-        if(pCustomMessage->Parameter1() == nullptr || pCustomMessage->Parameter1()->Type() != VT_I4) return S_FALSE;
-        if(pCustomMessage->Parameter2() == nullptr || pCustomMessage->Parameter2()->Type() != VT_I4) return S_FALSE;
+        if(custom_message->Parameter1() == nullptr || custom_message->Parameter1()->Type() != VT_I4) return S_FALSE;
+        if(custom_message->Parameter2() == nullptr || custom_message->Parameter2()->Type() != VT_I4) return S_FALSE;
 
-        const auto processId = pCustomMessage->Parameter1()->Value().lVal;
-        const auto threadId  = pCustomMessage->Parameter2()->Value().lVal;
-        logFile << "  child PID " << processId << "\n";
-        logFile << "  child TID " << threadId << "\n";
+        const auto process_id = custom_message->Parameter1()->Value().lVal;
+        const auto thread_id  = custom_message->Parameter2()->Value().lVal;
+        log_file_ << "  child PID " << process_id << "\n";
+        log_file_ << "  child TID " << thread_id << "\n";
 
         CComPtr<DkmProcess> process;
-        if(pCustomMessage->Connection()->FindLiveProcess(processId, &process) != S_OK)
+        if(custom_message->Connection()->FindLiveProcess(process_id, &process) != S_OK)
         {
-            logFile << "  Failed to find process\n";
-            logFile.flush();
+            log_file_ << "  Failed to find process\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
-        CComPtr<ChildProcessItem> childInfo;
-        childInfo.Attach(new ChildProcessItem());
+        CComPtr<ChildProcessItem> child_info;
+        child_info.Attach(new ChildProcessItem());
 
-        process->SetDataItem(DkmDataCreationDisposition::CreateNew, childInfo);
+        process->SetDataItem(DkmDataCreationDisposition::CreateNew, child_info);
 
-        if(CustomMessageType(pCustomMessage->MessageCode()) == CustomMessageType::ResumeChild)
+        if(CustomMessageType(custom_message->MessageCode()) == CustomMessageType::resume_child)
         {
-            auto* const hThread = OpenThread(THREAD_SUSPEND_RESUME, 0, threadId);
-            if(hThread == nullptr)
+            auto* const thread_handle = OpenThread(THREAD_SUSPEND_RESUME, 0, thread_id);
+            if(thread_handle == nullptr)
             {
-                logFile << "  Failed to open thread\n";
-                logFile.flush();
+                log_file_ << "  Failed to open thread\n";
+                log_file_.flush();
                 return S_FALSE;
             }
 
             // Resume the thread.
-            logFile << "  CALL ResumeThread\n";
-            logFile.flush();
-            const auto suspendCount = ResumeThread(hThread);
-            logFile << "  RESULT " << suspendCount << "\n";
-            logFile.flush();
-            CloseHandle(hThread);
+            log_file_ << "  CALL ResumeThread\n";
+            log_file_.flush();
+            const auto suspend_count = ResumeThread(thread_handle);
+            log_file_ << "  RESULT " << suspend_count << "\n";
+            log_file_.flush();
+            CloseHandle(thread_handle);
         }
     }
     break;
-    case CustomMessageType::ResumeParent:
+    case CustomMessageType::resume_parent:
     {
-        if(!settings.enabled) return S_OK;
+        if(!settings_.enabled) return S_OK;
 
-        if(pCustomMessage->Parameter1() == nullptr || pCustomMessage->Parameter1()->Type() != VT_I4) return S_FALSE;
-        if(pCustomMessage->Parameter2() == nullptr || pCustomMessage->Parameter2()->Type() != VT_I4) return S_FALSE;
+        if(custom_message->Parameter1() == nullptr || custom_message->Parameter1()->Type() != VT_I4) return S_FALSE;
+        if(custom_message->Parameter2() == nullptr || custom_message->Parameter2()->Type() != VT_I4) return S_FALSE;
 
-        const auto processId = pCustomMessage->Parameter1()->Value().lVal;
-        const auto threadId  = pCustomMessage->Parameter2()->Value().lVal;
-        logFile << "  parent PID " << processId << "\n";
-        logFile << "  parent TID " << threadId << "\n";
+        const auto process_id = custom_message->Parameter1()->Value().lVal;
+        const auto thread_id  = custom_message->Parameter2()->Value().lVal;
+        log_file_ << "  parent PID " << process_id << "\n";
+        log_file_ << "  parent TID " << thread_id << "\n";
 
         CComPtr<DkmProcess> process;
-        if(pCustomMessage->Connection()->FindLiveProcess(processId, &process) != S_OK)
+        if(custom_message->Connection()->FindLiveProcess(process_id, &process) != S_OK)
         {
-            logFile << "  Failed to find process\n";
-            logFile.flush();
+            log_file_ << "  Failed to find process\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
         CComPtr<DkmThread> thread;
-        if(process->FindSystemThread(threadId, &thread) != S_OK)
+        if(process->FindSystemThread(thread_id, &thread) != S_OK)
         {
-            logFile << "  Failed to find thread\n";
-            logFile.flush();
+            log_file_ << "  Failed to find thread\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
         UINT32 external_suspension_count;
         if(thread->Resume(true, &external_suspension_count) != S_OK)
         {
-            logFile << "  Failed to resume thread\n";
-            logFile.flush();
+            log_file_ << "  Failed to resume thread\n";
+            log_file_.flush();
             return S_FALSE;
         }
     }
@@ -729,18 +726,18 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::SendLower(
 }
 
 HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnModuleInstanceLoad(
-    DkmModuleInstance* pModuleInstance,
-    DkmWorkList* /*pWorkList*/,
-    DkmEventDescriptorS* /*pEventDescriptor*/)
+    DkmModuleInstance* module_instance,
+    DkmWorkList* /*work_list*/,
+    DkmEventDescriptorS* /*event_descriptor*/)
 {
-    if(!settings.enabled) return S_OK;
+    if(!settings_.enabled) return S_OK;
 
     // Check whether the loaded module is one of the Windows core DLLs that provide any of the Win32 API
     // functions for child process creation that we are interested in.
 
     // If it is not a native module, we are not interested (since the Windows core DLLs are native).
-    auto* const nativeModuleInstance = Native::DkmNativeModuleInstance::TryCast(pModuleInstance);
-    if(nativeModuleInstance == nullptr) return S_OK;
+    auto* const native_module_instance = Native::DkmNativeModuleInstance::TryCast(module_instance);
+    if(native_module_instance == nullptr) return S_OK;
 
     // kernel32.dll provides:
     //  - CreateProcessA / CreateProcessW
@@ -748,62 +745,62 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnModuleInstanceLoad(
     //  - CreateProcessAsUserA / CreateProcessAsUserW
     //  - CreateProcessWithTokenW
     //  - CreateProcessWithLogonW
-    if(DkmString::CompareOrdinalIgnoreCase(pModuleInstance->Name(), L"kernel32.dll") != 0 &&
-       DkmString::CompareOrdinalIgnoreCase(pModuleInstance->Name(), L"advapi32.dll") != 0)
+    if(DkmString::CompareOrdinalIgnoreCase(module_instance->Name(), L"kernel32.dll") != 0 &&
+       DkmString::CompareOrdinalIgnoreCase(module_instance->Name(), L"advapi32.dll") != 0)
     {
         return S_OK;
     }
 
     // Now, try to find any of the supported process creation functions in this module and create
     // a breakpoint for any that we find.
-    for(auto& functionName : createProcessFunctionNames)
+    for(auto& function_name : create_process_function_names_)
     {
-        if(DkmString::IsNullOrEmpty(functionName)) continue;
+        if(DkmString::IsNullOrEmpty(function_name)) continue;
 
         // Try to find the address of the current function in the module.
         CComPtr<Native::DkmNativeInstructionAddress> address;
-        if(nativeModuleInstance->FindExportName(functionName, true, &address) != S_OK) continue;
+        if(native_module_instance->FindExportName(function_name, true, &address) != S_OK) continue;
 
-        logFile << "OnModuleInstanceLoad (Debugger PID " << GetCurrentProcessId() << ")\n";
-        logFile << "  " << utf8_encode(pModuleInstance->Name()->Value()) << "\n";
-        logFile << "  Base address " << pModuleInstance->BaseAddress() << "\n";
-        logFile << "  Function address " << utf8_encode(functionName->Value()) << " @" << address->RVA() << "\n";
-        logFile.flush();
+        log_file_ << "OnModuleInstanceLoad (Debugger PID " << GetCurrentProcessId() << ")\n";
+        log_file_ << "  " << utf8_encode(module_instance->Name()->Value()) << "\n";
+        log_file_ << "  Base address " << module_instance->BaseAddress() << "\n";
+        log_file_ << "  Function address " << utf8_encode(function_name->Value()) << " @" << address->RVA() << "\n";
+        log_file_.flush();
 
         // TODO: Simplify this:
-        const auto functionType = [&functionName]() -> CreateFunctionType
+        const auto function_type = [&function_name]() -> CreateFunctionType
         {
-            if(std::wstring_view(functionName->Value(), functionName->Length()).starts_with(L"CreateProcessWithLogon"))
+            if(std::wstring_view(function_name->Value(), function_name->Length()).starts_with(L"CreateProcessWithLogon"))
             {
-                return CreateFunctionType::CreateProcessWithLogon;
+                return CreateFunctionType::create_process_with_logon;
             }
-            if(std::wstring_view(functionName->Value(), functionName->Length()).starts_with(L"CreateProcessWithToken"))
+            if(std::wstring_view(function_name->Value(), function_name->Length()).starts_with(L"CreateProcessWithToken"))
             {
-                return CreateFunctionType::CreateProcessWithToken;
+                return CreateFunctionType::create_process_with_token;
             }
-            if(std::wstring_view(functionName->Value(), functionName->Length()).starts_with(L"CreateProcessAsUser"))
+            if(std::wstring_view(function_name->Value(), function_name->Length()).starts_with(L"CreateProcessAsUser"))
             {
-                return CreateFunctionType::CreateProcessAsUser;
+                return CreateFunctionType::create_process_as_user;
             }
-            return CreateFunctionType::CreateProcess;
+            return CreateFunctionType::create_process;
         }();
 
         // Attach some information to the breakpoint about the function it has been generated for.
-        CComPtr<CreateInInfo> inInfo;
-        inInfo.Attach(new CreateInInfo(functionName->Value()[functionName->Length() - 1] == L'W', functionType));
+        CComPtr<CreateInInfo> in_info;
+        in_info.Attach(new CreateInInfo(function_name->Value()[function_name->Length() - 1] == L'W', function_type));
 
         CComPtr<Breakpoints::DkmRuntimeInstructionBreakpoint> breakpoint;
-        if(Breakpoints::DkmRuntimeInstructionBreakpoint::Create(sourceId, nullptr, address, false, inInfo, &breakpoint) != S_OK)
+        if(Breakpoints::DkmRuntimeInstructionBreakpoint::Create(source_id, nullptr, address, false, in_info, &breakpoint) != S_OK)
         {
-            logFile << "  FAILED to create breakpoint!\n";
-            logFile.flush();
+            log_file_ << "  FAILED to create breakpoint!\n";
+            log_file_.flush();
             continue;
         }
 
         if(breakpoint->Enable() != S_OK)
         {
-            logFile << "  FAILED to enable breakpoint!\n";
-            logFile.flush();
+            log_file_ << "  FAILED to enable breakpoint!\n";
+            log_file_.flush();
             continue;
         }
     }
@@ -811,22 +808,22 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnModuleInstanceLoad(
 }
 
 HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnRuntimeBreakpoint(
-    Breakpoints::DkmRuntimeBreakpoint* pRuntimeBreakpoint,
-    DkmThread*                         pThread,
-    bool /*HasException*/,
-    DkmEventDescriptorS* /*pEventDescriptor*/)
+    Breakpoints::DkmRuntimeBreakpoint* runtime_breakpoint,
+    DkmThread*                         thread,
+    bool /*has_exception*/,
+    DkmEventDescriptorS* /*event_descriptor*/)
 {
-    if(!settings.enabled) return S_OK;
+    if(!settings_.enabled) return S_OK;
 
-    logFile << "OnRuntimeBreakpoint (Debugger PID " << GetCurrentProcessId() << ")\n";
-    std::array<wchar_t, 64> guidStr = {L'\0'};
-    StringFromGUID2(pRuntimeBreakpoint->SourceId(), guidStr.data(), guidStr.size());
-    logFile << "  Source ID:" << utf8_encode(guidStr.data()) << "\n";
-    logFile.flush();
+    log_file_ << "OnRuntimeBreakpoint (Debugger PID " << GetCurrentProcessId() << ")\n";
+    std::array<wchar_t, 64> guid_str = {L'\0'};
+    StringFromGUID2(runtime_breakpoint->SourceId(), guid_str.data(), guid_str.size());
+    log_file_ << "  Source ID:" << utf8_encode(guid_str.data()) << "\n";
+    log_file_.flush();
 
-    CComPtr<CreateInInfo> inInfo;
-    pRuntimeBreakpoint->GetDataItem(&inInfo);
-    if(inInfo != nullptr)
+    CComPtr<CreateInInfo> in_info;
+    runtime_breakpoint->GetDataItem(&in_info);
+    if(in_info != nullptr)
     {
         // This is a breakpoint when entering a process creation function.
         // We will do the following things:
@@ -835,108 +832,108 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnRuntimeBreakpoint(
         //  - maybe, modify the passed arguments to force  suspended start.
         //  - create a new breakpoint that is triggered when the create process function is finished.
 
-        logFile << "  In PID " << pThread->Process()->LivePart()->Id << ": Start CreateProcess: W " << inInfo->GetIsUnicode() << " Func " << (int)inInfo->GetFunctionType() << "\n";
-        logFile.flush();
+        log_file_ << "  In PID " << thread->Process()->LivePart()->Id << ": Start CreateProcess: W " << in_info->get_is_unicode() << " Func " << (int)in_info->get_function_type() << "\n";
+        log_file_.flush();
 
         // Retrieve the current register values, required to extract function call arguments.
         CONTEXT      context;
-        const UINT32 contextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER; // NOLINT(misc-redundant-expression)
-        if(pThread->GetContext(contextFlags, &context, sizeof(CONTEXT)) != S_OK)
+        const UINT32 context_flags = CONTEXT_CONTROL | CONTEXT_INTEGER; // NOLINT(misc-redundant-expression)
+        if(thread->GetContext(context_flags, &context, sizeof(CONTEXT)) != S_OK)
         {
-            logFile << "  FAILED to retrieve thread context.\n";
-            logFile.flush();
+            log_file_ << "  FAILED to retrieve thread context.\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
         // FIXME: support remaining creation functions `CreateProcessWithToken` and `CreateProcessWithLogon`.
-        if(inInfo->GetFunctionType() == CreateFunctionType::CreateProcess)
+        if(in_info->get_function_type() == CreateFunctionType::create_process)
         {
-            return handleCallToCreateProcess<CreateProcessStack>(settings, logFile, pThread, context, static_cast<unsigned int>(inInfo->GetIsUnicode()) != 0U);
+            return handle_call_to_create_process<CreateProcessStack>(settings_, log_file_, thread, context, static_cast<unsigned int>(in_info->get_is_unicode()) != 0U);
         }
-        if(inInfo->GetFunctionType() == CreateFunctionType::CreateProcessAsUser)
+        if(in_info->get_function_type() == CreateFunctionType::create_process_as_user)
         {
-            return handleCallToCreateProcess<CreateProcessAsUserStack>(settings, logFile, pThread, context, inInfo->GetIsUnicode());
+            return handle_call_to_create_process<CreateProcessAsUserStack>(settings_, log_file_, thread, context, in_info->get_is_unicode());
         }
 
-        logFile << "  Unsupported create function type: " << ((int)inInfo->GetFunctionType()) << ".\n";
-        logFile.flush();
+        log_file_ << "  Unsupported create function type: " << ((int)in_info->get_function_type()) << ".\n";
+        log_file_.flush();
         return S_FALSE;
     }
 
-    CComPtr<CreateOutInfo> outInfo;
-    pRuntimeBreakpoint->GetDataItem(&outInfo);
-    if(outInfo != nullptr)
+    CComPtr<CreateOutInfo> out_info;
+    runtime_breakpoint->GetDataItem(&out_info);
+    if(out_info != nullptr)
     {
         // This is a breakpoint when a process creation has been completed.
         // We will do the following things:
         //  - extract the process ID if of the created child process.
         //  - inform the debug client (VS Code) about the newly created process, so that it can attach to it.
 
-        logFile << "  In PID " << pThread->Process()->LivePart()->Id << ": Finish CreateProcess"
-                << "\n";
-        logFile.flush();
+        log_file_ << "  In PID " << thread->Process()->LivePart()->Id << ": Finish CreateProcess"
+                  << "\n";
+        log_file_.flush();
 
-        pRuntimeBreakpoint->Close(); // Remove this breakpoint. We will create a new one for the next call.
+        runtime_breakpoint->Close(); // Remove this breakpoint. We will create a new one for the next call.
 
         // Retrieve the current register values, required to extract the function return value.
         CONTEXT      context;
-        const UINT32 contextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER; // NOLINT(misc-redundant-expression)
-        if(pThread->GetContext(contextFlags, &context, sizeof(CONTEXT)) != S_OK)
+        const UINT32 context_flags = CONTEXT_CONTROL | CONTEXT_INTEGER; // NOLINT(misc-redundant-expression)
+        if(thread->GetContext(context_flags, &context, sizeof(CONTEXT)) != S_OK)
         {
-            logFile << "  FAILED to retrieve thread context.\n";
-            logFile.flush();
+            log_file_ << "  FAILED to retrieve thread context.\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
         // The RAX register holds the return value.
-        logFile << "  CreateProcess returned " << context.Rax << "\n";
+        log_file_ << "  CreateProcess returned " << context.Rax << "\n";
         if(context.Rax == 0)
         {
             // Nothing to attach to if the CreateProcess call failed.
-            logFile.flush();
+            log_file_.flush();
             return S_OK;
         }
 
         // Read the process information structure from the stack. This should have been populated with information
         // about the newly created process.
-        PROCESS_INFORMATION procInfo;
-        if(pThread->Process()->ReadMemory(outInfo->GetProcessInformationAddress(), DkmReadMemoryFlags::None, &procInfo, sizeof(PROCESS_INFORMATION), nullptr) != S_OK)
+        PROCESS_INFORMATION proc_info;
+        if(thread->Process()->ReadMemory(out_info->get_process_information_address(), DkmReadMemoryFlags::None, &proc_info, sizeof(PROCESS_INFORMATION), nullptr) != S_OK)
         {
-            logFile << "  FAILED to read process information!\n";
-            logFile.flush();
+            log_file_ << "  FAILED to read process information!\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
         // Try to extract the application name of the created child process.
-        std::wstring applicationName;
-        auto* const  processHandle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, procInfo.dwProcessId);
-        if(processHandle != nullptr)
+        std::wstring application_name;
+        auto* const  process_handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, proc_info.dwProcessId);
+        if(process_handle != nullptr)
         {
             std::array<WCHAR, MAX_PATH> buffer; // FIXME: handle paths longer than MAX_PATH
 
-            const auto size = GetProcessImageFileNameW(processHandle, buffer.data(), buffer.size());
+            const auto size = GetProcessImageFileNameW(process_handle, buffer.data(), buffer.size());
             if(size > 0)
             {
-                applicationName = std::filesystem::path(buffer.data()).filename().native();
+                application_name = std::filesystem::path(buffer.data()).filename().native();
             }
-            CloseHandle(processHandle);
+            CloseHandle(process_handle);
         }
 
-        logFile << "  Child App Name " << utf8_encode(applicationName) << "\n";
-        logFile << "  Child PID " << procInfo.dwProcessId << " TID " << procInfo.dwThreadId << "\n";
-        logFile << "  Child P-HANDLE " << procInfo.hProcess << " T-HANDLE " << procInfo.hThread << "\n";
-        logFile.flush();
+        log_file_ << "  Child App Name " << utf8_encode(application_name) << "\n";
+        log_file_ << "  Child PID " << proc_info.dwProcessId << " TID " << proc_info.dwThreadId << "\n";
+        log_file_ << "  Child P-HANDLE " << proc_info.hProcess << " T-HANDLE " << proc_info.hThread << "\n";
+        log_file_.flush();
 
         // To make sure all this does not impose any unwanted effects, we suspend
         // the current parent process here, and only resume it when the debugger
         // has been attached successfully to the child process.
-        if(settings.suspendParents)
+        if(settings_.suspend_parents)
         {
             UINT32 external_suspension_count;
-            if(pThread->Suspend(true, &external_suspension_count) != 0)
+            if(thread->Suspend(true, &external_suspension_count) != 0)
             {
-                logFile << "  FAILED to suspend parent process.\n";
-                logFile.flush();
+                log_file_ << "  FAILED to suspend parent process.\n";
+                log_file_.flush();
                 return S_FALSE;
             }
         }
@@ -952,34 +949,34 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnRuntimeBreakpoint(
         // so far.
         // The following messages is formatted in such a way, that we can hopefully parse all the information
         // back in the VS Code extension side.
-        CComPtr<DkmString> messageStr;
-        if(DkmString::Create((L"ChildDebugger: attach to child NAME '" + applicationName +
-                              L"' PPID " + std::to_wstring(pThread->Process()->LivePart()->Id) +
-                              L" PTID " + std::to_wstring(pThread->SystemPart()->Id) +
-                              L" CPID " + std::to_wstring(procInfo.dwProcessId) +
-                              L" CTID " + std::to_wstring(procInfo.dwThreadId) +
-                              (outInfo->GetSuspended() ? L" CSUSPENDED" : L"") +
-                              (settings.suspendParents ? L" PSUSPENDED" : L"") + L"\n")
+        CComPtr<DkmString> message_str;
+        if(DkmString::Create((L"ChildDebugger: attach to child NAME '" + application_name +
+                              L"' PPID " + std::to_wstring(thread->Process()->LivePart()->Id) +
+                              L" PTID " + std::to_wstring(thread->SystemPart()->Id) +
+                              L" CPID " + std::to_wstring(proc_info.dwProcessId) +
+                              L" CTID " + std::to_wstring(proc_info.dwThreadId) +
+                              (out_info->get_suspended() ? L" CSUSPENDED" : L"") +
+                              (settings_.suspend_parents ? L" PSUSPENDED" : L"") + L"\n")
                                  .c_str(),
-                             &messageStr) != S_OK)
+                             &message_str) != S_OK)
         {
-            logFile << "  FAILED to create string for message!\n";
-            logFile.flush();
+            log_file_ << "  FAILED to create string for message!\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
         CComPtr<DkmUserMessage> message;
-        if(DkmUserMessage::Create(pThread->Connection(), pThread->Process(), DkmUserMessageOutputKind::UnfilteredOutputWindowMessage, messageStr, MB_OK, S_OK, &message) != S_OK)
+        if(DkmUserMessage::Create(thread->Connection(), thread->Process(), DkmUserMessageOutputKind::UnfilteredOutputWindowMessage, message_str, MB_OK, S_OK, &message) != S_OK)
         {
-            logFile << "  FAILED to create user message!\n";
-            logFile.flush();
+            log_file_ << "  FAILED to create user message!\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
         if(message->Post() != S_OK)
         {
-            logFile << "  FAILED to post user message!\n";
-            logFile.flush();
+            log_file_ << "  FAILED to post user message!\n";
+            log_file_.flush();
             return S_FALSE;
         }
 
@@ -990,52 +987,52 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnRuntimeBreakpoint(
 }
 
 HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnEmbeddedBreakpointHitReceived(
-    _In_ DkmThread*                 pThread,
-    _In_opt_ DkmInstructionAddress* pInstructionAddress,
-    _In_ bool /*ShowAsException*/,
-    _In_ DkmEventDescriptorS* pEventDescriptor)
+    _In_ DkmThread*                 thread,
+    _In_opt_ DkmInstructionAddress* instruction_address,
+    _In_ bool /*show_as_exception*/,
+    _In_ DkmEventDescriptorS* event_descriptor)
 {
-    if(!settings.enabled) return S_OK;
-    if(!settings.skipInitialBreakpoint) return S_OK;
+    if(!settings_.enabled) return S_OK;
+    if(!settings_.skip_initial_breakpoint) return S_OK;
 
-    logFile << "On OnEmbeddedBreakpointHitReceived (Debugger PID " << GetCurrentProcessId() << ")\n";
+    log_file_ << "On OnEmbeddedBreakpointHitReceived (Debugger PID " << GetCurrentProcessId() << ")\n";
 
     // The initial breakpoint is in ntdll.dll!LdrpDoDebuggerBreak()
-    if(DkmString::CompareOrdinalIgnoreCase(pInstructionAddress->ModuleInstance()->Name(), L"ntdll.dll") != 0) return S_OK;
+    if(DkmString::CompareOrdinalIgnoreCase(instruction_address->ModuleInstance()->Name(), L"ntdll.dll") != 0) return S_OK;
 
-    logFile << "  IN NTDLL\n";
-    logFile.flush();
+    log_file_ << "  IN NTDLL\n";
+    log_file_.flush();
 
-    logFile << " THREAD " << pThread << "\n";
-    logFile.flush();
+    log_file_ << " THREAD " << thread << "\n";
+    log_file_.flush();
 
-    if(pThread == nullptr) return S_FALSE;
-    logFile << " PROCESS " << pThread->Process() << "\n";
-    logFile.flush();
-    if(pThread->Process() == nullptr) return S_FALSE;
+    if(thread == nullptr) return S_FALSE;
+    log_file_ << " PROCESS " << thread->Process() << "\n";
+    log_file_.flush();
+    if(thread->Process() == nullptr) return S_FALSE;
 
-    logFile << "  Has process\n";
-    logFile.flush();
+    log_file_ << "  Has process\n";
+    log_file_.flush();
 
-    CComPtr<ChildProcessItem> childInfo;
-    pThread->Process()->GetDataItem(&childInfo);
-    if(!childInfo) return S_OK;
+    CComPtr<ChildProcessItem> child_info;
+    thread->Process()->GetDataItem(&child_info);
+    if(!child_info) return S_OK;
 
-    logFile << "  Has child info\n";
-    logFile << "    Passed Initial Breakpoint " << childInfo->GetPassedInitialBreakpoint() << "\n";
-    logFile.flush();
+    log_file_ << "  Has child info\n";
+    log_file_ << "    Passed Initial Breakpoint " << child_info->get_passed_initial_breakpoint() << "\n";
+    log_file_.flush();
 
     // Skip if we passed the initial breakpoint already
-    if(childInfo->GetPassedInitialBreakpoint()) return S_OK;
+    if(child_info->get_passed_initial_breakpoint()) return S_OK;
 
     // This has to be the initial breakpoint, so suppress handling it.
-    pEventDescriptor->Suppress();
+    event_descriptor->Suppress();
 
     // Set, that we passed the initial breakpoint for this process.
-    childInfo->SetPassedInitialBreakpoint();
+    child_info->set_passed_initial_breakpoint();
 
-    logFile << "  Suppressed\n";
-    logFile.flush();
+    log_file_ << "  Suppressed\n";
+    log_file_.flush();
 
     return S_OK;
 }

--- a/vsdbg-engine-extension/src/ChildDebuggerService.h
+++ b/vsdbg-engine-extension/src/ChildDebuggerService.h
@@ -11,22 +11,22 @@
 
 struct ProcessConfig
 {
-    std::optional<std::wstring> applicationName = std::nullopt;
-    std::optional<std::wstring> commandLine     = std::nullopt;
-    bool                        attach          = true;
+    std::optional<std::wstring> application_name = std::nullopt;
+    std::optional<std::wstring> command_line     = std::nullopt;
+    bool                        attach           = true;
 };
 
 struct ChildDebuggerSettings
 {
     bool enabled = false;
 
-    bool suspendChildren = true;
-    bool suspendParents  = true;
+    bool suspend_children = true;
+    bool suspend_parents  = true;
 
-    bool skipInitialBreakpoint = true;
+    bool skip_initial_breakpoint = true;
 
-    std::vector<ProcessConfig> processConfigs;
-    bool                       attachOthers = true;
+    std::vector<ProcessConfig> process_configs;
+    bool                       attach_others = true;
 };
 
 class ATL_NO_VTABLE CChildDebuggerService :
@@ -48,31 +48,31 @@ public:
     CChildDebuggerService& operator=(CChildDebuggerService&&) = delete;
 
 public:
-    virtual HRESULT STDMETHODCALLTYPE SendLower(
+    HRESULT STDMETHODCALLTYPE SendLower(
         Microsoft::VisualStudio::Debugger::DkmCustomMessage*  custom_message,
-        Microsoft::VisualStudio::Debugger::DkmCustomMessage** ppReplyMessage) override;
+        Microsoft::VisualStudio::Debugger::DkmCustomMessage** reply_message) override;
 
-    virtual HRESULT STDMETHODCALLTYPE OnModuleInstanceLoad(
+    HRESULT STDMETHODCALLTYPE OnModuleInstanceLoad(
         _In_ Microsoft::VisualStudio::Debugger::DkmModuleInstance* module_instance,
-        _In_ Microsoft::VisualStudio::Debugger::DkmWorkList* pWorkList,
-        _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* pEventDescriptor) override;
+        _In_ Microsoft::VisualStudio::Debugger::DkmWorkList* work_list,
+        _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* event_descriptor) override;
 
-    virtual HRESULT STDMETHODCALLTYPE OnRuntimeBreakpoint(
+    HRESULT STDMETHODCALLTYPE OnRuntimeBreakpoint(
         _In_ Microsoft::VisualStudio::Debugger::Breakpoints::DkmRuntimeBreakpoint* runtime_breakpoint,
-        _In_ Microsoft::VisualStudio::Debugger::DkmThread* pThread,
-        _In_ bool                                          HasException,
-        _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* pEventDescriptor) override;
+        _In_ Microsoft::VisualStudio::Debugger::DkmThread* thread,
+        _In_ bool                                          has_exception,
+        _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* event_descriptor) override;
 
-    virtual HRESULT STDMETHODCALLTYPE OnEmbeddedBreakpointHitReceived(
-        _In_ Microsoft::VisualStudio::Debugger::DkmThread* pThread,
+    HRESULT STDMETHODCALLTYPE OnEmbeddedBreakpointHitReceived(
+        _In_ Microsoft::VisualStudio::Debugger::DkmThread* thread,
         _In_opt_ Microsoft::VisualStudio::Debugger::DkmInstructionAddress* instruction_address,
-        _In_ bool                                                          ShowAsException,
+        _In_ bool                                                          show_as_exception,
         _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* event_descriptor) override;
 
 private:
-    ChildDebuggerSettings                                                settings;
-    std::ofstream                                                        logFile;
-    std::array<CComPtr<Microsoft::VisualStudio::Debugger::DkmString>, 6> createProcessFunctionNames;
+    ChildDebuggerSettings                                                settings_;
+    std::ofstream                                                        log_file_;
+    std::array<CComPtr<Microsoft::VisualStudio::Debugger::DkmString>, 6> create_process_function_names_;
 };
 
 OBJECT_ENTRY_AUTO(CChildDebuggerService::ClassId, CChildDebuggerService)

--- a/vsdbg-engine-extension/src/ChildDebuggerService.h
+++ b/vsdbg-engine-extension/src/ChildDebuggerService.h
@@ -42,27 +42,32 @@ public:
     DECLARE_NO_REGISTRY();
     DECLARE_NOT_AGGREGATABLE(CChildDebuggerService);
 
+    CChildDebuggerService(CChildDebuggerService&)             = delete;
+    CChildDebuggerService(CChildDebuggerService&&)            = delete;
+    CChildDebuggerService& operator=(CChildDebuggerService&)  = delete;
+    CChildDebuggerService& operator=(CChildDebuggerService&&) = delete;
+
 public:
     virtual HRESULT STDMETHODCALLTYPE SendLower(
-        Microsoft::VisualStudio::Debugger::DkmCustomMessage*  pCustomMessage,
+        Microsoft::VisualStudio::Debugger::DkmCustomMessage*  custom_message,
         Microsoft::VisualStudio::Debugger::DkmCustomMessage** ppReplyMessage) override;
 
     virtual HRESULT STDMETHODCALLTYPE OnModuleInstanceLoad(
-        _In_ Microsoft::VisualStudio::Debugger::DkmModuleInstance* pModuleInstance,
+        _In_ Microsoft::VisualStudio::Debugger::DkmModuleInstance* module_instance,
         _In_ Microsoft::VisualStudio::Debugger::DkmWorkList* pWorkList,
         _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* pEventDescriptor) override;
 
     virtual HRESULT STDMETHODCALLTYPE OnRuntimeBreakpoint(
-        _In_ Microsoft::VisualStudio::Debugger::Breakpoints::DkmRuntimeBreakpoint* pRuntimeBreakpoint,
+        _In_ Microsoft::VisualStudio::Debugger::Breakpoints::DkmRuntimeBreakpoint* runtime_breakpoint,
         _In_ Microsoft::VisualStudio::Debugger::DkmThread* pThread,
         _In_ bool                                          HasException,
         _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* pEventDescriptor) override;
 
     virtual HRESULT STDMETHODCALLTYPE OnEmbeddedBreakpointHitReceived(
         _In_ Microsoft::VisualStudio::Debugger::DkmThread* pThread,
-        _In_opt_ Microsoft::VisualStudio::Debugger::DkmInstructionAddress* pInstructionAddress,
+        _In_opt_ Microsoft::VisualStudio::Debugger::DkmInstructionAddress* instruction_address,
         _In_ bool                                                          ShowAsException,
-        _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* pEventDescriptor) override;
+        _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* event_descriptor) override;
 
 private:
     ChildDebuggerSettings                                                settings;

--- a/vsdbg-engine-extension/src/ChildDebuggerService.h
+++ b/vsdbg-engine-extension/src/ChildDebuggerService.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <array>
-#include <vector>
-#include <string>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include <fstream>
 
@@ -12,8 +12,8 @@
 struct ProcessConfig
 {
     std::optional<std::wstring> applicationName = std::nullopt;
-    std::optional<std::wstring> commandLine = std::nullopt;
-    bool attach = true;
+    std::optional<std::wstring> commandLine     = std::nullopt;
+    bool                        attach          = true;
 };
 
 struct ChildDebuggerSettings
@@ -26,12 +26,12 @@ struct ChildDebuggerSettings
     bool skipInitialBreakpoint = true;
 
     std::vector<ProcessConfig> processConfigs;
-    bool attachOthers = true;
+    bool                       attachOthers = true;
 };
 
 class ATL_NO_VTABLE CChildDebuggerService :
     public CChildDebuggerServiceContract,
-	public CComObjectRootEx<CComMultiThreadModel>,
+    public CComObjectRootEx<CComMultiThreadModel>,
     public CComCoClass<CChildDebuggerService, &CChildDebuggerServiceContract::ClassId>
 {
 protected:
@@ -44,7 +44,7 @@ public:
 
 public:
     virtual HRESULT STDMETHODCALLTYPE SendLower(
-        Microsoft::VisualStudio::Debugger::DkmCustomMessage* pCustomMessage,
+        Microsoft::VisualStudio::Debugger::DkmCustomMessage*  pCustomMessage,
         Microsoft::VisualStudio::Debugger::DkmCustomMessage** ppReplyMessage) override;
 
     virtual HRESULT STDMETHODCALLTYPE OnModuleInstanceLoad(
@@ -55,7 +55,7 @@ public:
     virtual HRESULT STDMETHODCALLTYPE OnRuntimeBreakpoint(
         _In_ Microsoft::VisualStudio::Debugger::Breakpoints::DkmRuntimeBreakpoint* pRuntimeBreakpoint,
         _In_ Microsoft::VisualStudio::Debugger::DkmThread* pThread,
-        _In_ bool HasException,
+        _In_ bool                                          HasException,
         _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* pEventDescriptor) override;
 
     virtual HRESULT STDMETHODCALLTYPE OnEmbeddedBreakpointHitReceived(
@@ -65,8 +65,8 @@ public:
         _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* pEventDescriptor) override;
 
 private:
-    ChildDebuggerSettings settings;
-    std::ofstream logFile;
+    ChildDebuggerSettings                                                settings;
+    std::ofstream                                                        logFile;
     std::array<CComPtr<Microsoft::VisualStudio::Debugger::DkmString>, 6> createProcessFunctionNames;
 };
 

--- a/vsdbg-engine-extension/src/dllmain.cpp
+++ b/vsdbg-engine-extension/src/dllmain.cpp
@@ -7,9 +7,10 @@
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 CChildDebuggerModule _AtlModule;
 
-extern "C" BOOL WINAPI DllMain([[maybe_unused]] HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern "C" BOOL WINAPI DllMain([[maybe_unused]] HINSTANCE instance, DWORD reason, LPVOID reserved)
 {
-    return _AtlModule.DllMain(dwReason, lpReserved);
+    return _AtlModule.DllMain(reason, reserved);
 }
 
 STDAPI DllCanUnloadNow(void)

--- a/vsdbg-engine-extension/src/dllmain.cpp
+++ b/vsdbg-engine-extension/src/dllmain.cpp
@@ -8,7 +8,7 @@ CChildDebuggerModule _AtlModule;
 
 extern "C" BOOL WINAPI DllMain([[maybe_unused]] HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {
-	return _AtlModule.DllMain(dwReason, lpReserved); 
+    return _AtlModule.DllMain(dwReason, lpReserved);
 }
 
 STDAPI DllCanUnloadNow(void)

--- a/vsdbg-engine-extension/src/dllmain.cpp
+++ b/vsdbg-engine-extension/src/dllmain.cpp
@@ -4,6 +4,7 @@
 
 #include "dllmain.h"
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 CChildDebuggerModule _AtlModule;
 
 extern "C" BOOL WINAPI DllMain([[maybe_unused]] HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)

--- a/vsdbg-engine-extension/src/dllmain.h
+++ b/vsdbg-engine-extension/src/dllmain.h
@@ -4,4 +4,5 @@ class CChildDebuggerModule : public CAtlDllModuleT<CChildDebuggerModule>
 {
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, bugprone-reserved-identifier, readability-identifier-naming)
 extern class CChildDebuggerModule _AtlModule;

--- a/vsdbg-engine-extension/tests/callee/main.cpp
+++ b/vsdbg-engine-extension/tests/callee/main.cpp
@@ -6,7 +6,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
     std::wcout << L"  CALLEE (" << GetCurrentProcessId() << L"): initialized" << std::endl;
 

--- a/vsdbg-engine-extension/tests/callee/main.cpp
+++ b/vsdbg-engine-extension/tests/callee/main.cpp
@@ -1,7 +1,7 @@
 
+#include <chrono>
 #include <iostream>
 #include <thread>
-#include <chrono>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/vsdbg-engine-extension/tests/caller/main.cpp
+++ b/vsdbg-engine-extension/tests/caller/main.cpp
@@ -86,11 +86,11 @@ options parse_command_line(int argc, wchar_t* argv[]) // NOLINT(modernize-avoid-
             result.child_args.reserve(argc - arg_next);
             for(int arg_j = arg_next; arg_j < argc; ++arg_j)
             {
-                result.child_args.push_back(argv[arg_j]);
+                result.child_args.emplace_back(argv[arg_j]);
             }
             break;
         }
-        else if(child_path != std::nullopt)
+        else if(child_path.has_value())
         {
             print_error_and_exit(std::format(L"Multiple paths not supported: first was '{}' current is '{}'", child_path->c_str(), current_arg));
         }
@@ -147,7 +147,7 @@ void append_quoted_command_line_argument(std::wstring& command_line, std::wstrin
             command_line.append(num_backslashes * 2, L'\\');
             break;
         }
-        else if(*it == L'"')
+        if(*it == L'"')
         {
             command_line.append(num_backslashes * 2 + 1, L'\\');
             command_line.push_back(*it);
@@ -178,6 +178,7 @@ std::optional<std::wstring> make_command_line(const options& opts)
     return command_line;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
 int wmain(int argc, wchar_t* argv[])
 {
     const auto opts = parse_command_line(argc, argv);
@@ -214,7 +215,7 @@ int wmain(int argc, wchar_t* argv[])
 
     if(opts.suspend)
     {
-        const auto childMainThread = OpenThread(THREAD_SUSPEND_RESUME, false, process_info.dwThreadId);
+        auto* const childMainThread = OpenThread(THREAD_SUSPEND_RESUME, 0, process_info.dwThreadId);
         if(childMainThread == nullptr)
         {
             std::wcout << L"  CALLER (" << GetCurrentProcessId() << L"): failed to open child process thread: " << result << std::endl;

--- a/vsdbg-engine-extension/tests/caller/main.cpp
+++ b/vsdbg-engine-extension/tests/caller/main.cpp
@@ -1,19 +1,19 @@
 
+#include <chrono>
 #include <filesystem>
 #include <iostream>
 #include <thread>
-#include <chrono>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
 struct options
 {
-    std::filesystem::path child_path;
+    std::filesystem::path     child_path;
     std::vector<std::wstring> child_args;
 
-    bool suspend = false;
-    bool wait = false;
+    bool suspend     = false;
+    bool wait        = false;
     bool no_app_name = false;
 
     std::chrono::seconds init_sleep_time    = std::chrono::seconds(1);
@@ -54,8 +54,8 @@ void print_usage()
 
 options parse_command_line(int argc, wchar_t* argv[]) // NOLINT(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 {
-    options result;
-    bool    help = false;
+    options                              result;
+    bool                                 help = false;
     std::optional<std::filesystem::path> child_path;
     for(int arg_i = 1; arg_i < argc; ++arg_i)
     {
@@ -188,8 +188,8 @@ int wmain(int argc, wchar_t* argv[])
 
     auto command_line = make_command_line(opts);
 
-    const DWORD creation_flags = opts.suspend ? CREATE_SUSPENDED : 0;
-    STARTUPINFOW info={sizeof(info)};
+    const DWORD         creation_flags = opts.suspend ? CREATE_SUSPENDED : 0;
+    STARTUPINFOW        info           = {sizeof(info)};
     PROCESS_INFORMATION process_info;
 
     const auto result = CreateProcessW(

--- a/vsdbg-engine-extension/tests/caller/main.cpp
+++ b/vsdbg-engine-extension/tests/caller/main.cpp
@@ -7,7 +7,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-struct options
+struct Options
 {
     std::filesystem::path     child_path;
     std::vector<std::wstring> child_args;
@@ -52,9 +52,9 @@ void print_usage()
     print_usage_and_exit(EXIT_FAILURE);
 }
 
-options parse_command_line(int argc, wchar_t* argv[]) // NOLINT(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+Options parse_command_line(int argc, wchar_t* argv[]) // NOLINT(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 {
-    options                              result;
+    Options                              result;
     bool                                 help = false;
     std::optional<std::filesystem::path> child_path;
     for(int arg_i = 1; arg_i < argc; ++arg_i)
@@ -162,7 +162,7 @@ void append_quoted_command_line_argument(std::wstring& command_line, std::wstrin
     command_line.push_back(L'"');
 }
 
-std::optional<std::wstring> make_command_line(const options& opts)
+std::optional<std::wstring> make_command_line(const Options& opts)
 {
     if(opts.child_args.empty() && !opts.no_app_name) return std::nullopt;
 
@@ -215,8 +215,8 @@ int wmain(int argc, wchar_t* argv[])
 
     if(opts.suspend)
     {
-        auto* const childMainThread = OpenThread(THREAD_SUSPEND_RESUME, 0, process_info.dwThreadId);
-        if(childMainThread == nullptr)
+        auto* const child_main_thread = OpenThread(THREAD_SUSPEND_RESUME, 0, process_info.dwThreadId);
+        if(child_main_thread == nullptr)
         {
             std::wcout << L"  CALLER (" << GetCurrentProcessId() << L"): failed to open child process thread: " << result << std::endl;
             return EXIT_FAILURE;
@@ -224,9 +224,9 @@ int wmain(int argc, wchar_t* argv[])
 
         std::this_thread::sleep_for(opts.suspend_sleep_time);
 
-        ResumeThread(childMainThread);
+        ResumeThread(child_main_thread);
         std::wcout << L"  CALLER (" << GetCurrentProcessId() << L"): resumed child" << std::endl;
-        CloseHandle(childMainThread);
+        CloseHandle(child_main_thread);
     }
 
     std::this_thread::sleep_for(opts.final_sleep_time);


### PR DESCRIPTION
Adds workflows to check the formatting of the C++ source code via `clang-format` and some static analysis via `clang-tidy`.