### PR TITLE
Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,12 @@ jobs:
           -G Ninja `
           -DCMAKE_BUILD_TYPE=Debug `
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
-          -DCMAKE_INSTALL_PREFIX=vsdbg-engine-extension
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension"
   
-      - name: Build VSDbg Engine Extension
+      - name: Build & Install VSDbg Engine Extension
         run: |
           cd build
-          ninja
+          ninja install
 
       - name: Compile VSCode Test Sources
         run: npm run pretest

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -55,16 +55,11 @@ jobs:
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension"
   
-      - name: Build VSDbg Engine Extension
-        run: |
-          cd build
-          ninja
-
-      - name: Install VSDbg Engine Extension
+      - name: Build & Install VSDbg Engine Extension
         run: |
           cd build
           ninja install
-  
+
       - name: Add build info
         run: |
           "ref:    ${{ github.ref_name }}`n" + `

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "childdebugger",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "childdebugger",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/chai": "^4.3.16",
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.19.39",
@@ -16,6 +17,7 @@
         "@typescript-eslint/eslint-plugin": "7.16",
         "@typescript-eslint/parser": "7.16",
         "@vscode/test-electron": "^2.3.9",
+        "chai": "^4.4.1",
         "eslint": "^8.28.0",
         "glob": "^8.1.0",
         "mocha": "^10.1.0",
@@ -230,6 +232,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.16",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.16.tgz",
+      "integrity": "sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.21.2",
@@ -860,6 +868,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -983,6 +1000,24 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -997,6 +1032,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1155,6 +1202,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -1625,6 +1684,15 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/glob": {
@@ -2174,6 +2242,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2536,6 +2613,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/picocolors": {
@@ -3148,6 +3234,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "vscode:uninstall": "node ./dist/uninstall.js"
   },
   "devDependencies": {
+    "@types/chai": "^4.3.16",
     "@types/glob": "^8.0.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.19.39",
@@ -108,6 +109,7 @@
     "@typescript-eslint/eslint-plugin": "7.16",
     "@typescript-eslint/parser": "7.16",
     "@vscode/test-electron": "^2.3.9",
+    "chai": "^4.4.1",
     "eslint": "^8.28.0",
     "glob": "^8.1.0",
     "mocha": "^10.1.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { installVsDbgEngineExtensionIntegration } from './integration';
+import { installVsDbgEngineExtensionIntegration, uninstallVsDbgEngineExtensionIntegration } from './integration';
 
 const outputChannelName = "Child Debugger";
 
@@ -41,15 +41,13 @@ const childDebuggerSourceId = "{0BB89D05-9EAD-4295-9A74-A241583DE420}";
 
 export function activate(context: vscode.ExtensionContext) {
 
-	if(context.extensionMode === vscode.ExtensionMode.Production) {
-		installVsDbgEngineExtensionIntegration(context.extensionPath).catch().then((value) => {
-			outputChannel.appendLine("Successfully installed VS Debug Engine integration.");
-		}, (reason) => {
-			vscode.window.showErrorMessage(`Failed to install VS Debug Engine integration.\nSee "${outputChannelName}" output channel for more information.`);
-			outputChannel.appendLine("Failed to install VS Debug Engine integration:");
-			outputChannel.appendLine(`  ${reason}`);
-		});
-	}
+	installVsDbgEngineExtensionIntegration(context.extensionPath).catch().then((value) => {
+		outputChannel.appendLine("Successfully installed VS Debug Engine integration.");
+	}, (reason) => {
+		vscode.window.showErrorMessage(`Failed to install VS Debug Engine integration.\nSee "${outputChannelName}" output channel for more information.`);
+		outputChannel.appendLine("Failed to install VS Debug Engine integration:");
+		outputChannel.appendLine(`  ${reason}`);
+	});
 
 	vscode.debug.registerDebugAdapterTrackerFactory('*', {
 		createDebugAdapterTracker(session: vscode.DebugSession) {
@@ -237,4 +235,6 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 }
 
-export function deactivate() { }
+export function deactivate() {
+	// uninstallVsDbgEngineExtensionIntegration();
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,8 +6,8 @@ const outputChannelName = "Child Debugger";
 var outputChannel = vscode.window.createOutputChannel(outputChannelName);
 
 interface EngineProcessConfig {
-	applicationName: string|undefined,
-	commandLine: string|undefined,
+	applicationName: string | undefined,
+	commandLine: string | undefined,
 	attach: boolean,
 }
 interface EngineSettings {
@@ -160,12 +160,12 @@ export function activate(context: vscode.ExtensionContext) {
 			return;
 		}
 
-		var processConfigs : EngineProcessConfig[] = [];
+		var processConfigs: EngineProcessConfig[] = [];
 		for (const entry of configuration.get<any[]>("filter.childProcesses", [])) {
 			processConfigs.push({
-				applicationName : entry['applicationName'],
-				commandLine : entry['commandLine'],
-				attach : entry['attach'],
+				applicationName: entry['applicationName'],
+				commandLine: entry['commandLine'],
+				attach: entry['attach'],
 			});
 		}
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,6 +1,7 @@
+import * as cp from 'child_process';
 import * as path from 'path';
 
-import { runTests } from '@vscode/test-electron';
+import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } from '@vscode/test-electron';
 
 async function main() {
 	try {
@@ -11,6 +12,19 @@ async function main() {
 		// The path to test runner
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+
+		const vscodeExecutablePath = await downloadAndUnzipVSCode();
+		const [cliPath, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+
+		// Use cp.spawn / cp.exec for custom setup
+		cp.spawnSync(
+			cliPath,
+			[...args, '--install-extension', 'ms-vscode.cpptools'],
+			{
+				encoding: 'utf-8',
+				stdio: 'inherit'
+			}
+		);
 
 		// Download VS Code, unzip it and run the integration test
 		await runTests({ extensionDevelopmentPath, extensionTestsPath });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,176 @@
-import * as assert from 'assert';
+import { assert } from 'chai';
+import { EventEmitter } from 'events';
+import * as path from 'path';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 // import * as myExtension from '../../extension';
 
-suite('Extension Test Suite', () => {
+async function startDebuggingAndWait(configuration: vscode.DebugConfiguration) {
+
+	let startedSessions: vscode.DebugSession[] = [];
+
+	const eventEmitter = new EventEmitter();
+
+	vscode.debug.onDidStartDebugSession((session) => {
+		startedSessions.push(session);
+		eventEmitter.emit('startSession', session);
+	});
+	vscode.debug.onDidTerminateDebugSession((session) => {
+		eventEmitter.emit('terminateSession', session);
+	});
+
+	const parentSessionStart = new Promise<vscode.DebugSession>((resolve) => {
+		eventEmitter.on('startSession', resolve);
+	});
+
+	// vscode.debug.registerDebugAdapterTrackerFactory('*', {
+	// 	createDebugAdapterTracker(session: vscode.DebugSession) {
+	// 		return {
+	// 			onDidSendMessage: (m) => {
+	// 				if (m.type !== "event" ||
+	// 					m.event !== "output" ||
+	// 					m.body.category !== "console") {
+	// 					return;
+	// 				}
+	// 				console.log(m.body.output);
+	// 			}
+	// 		};
+	// 	}
+	// });
+
+	await vscode.debug.startDebugging(undefined, configuration);
+
+	const parentSession = await parentSessionStart;
+
+	await new Promise<void>((resolve) => {
+		eventEmitter.on('terminateSession', (session: vscode.DebugSession) => {
+			if (session.name !== parentSession.name) {
+				return;
+			}
+			resolve();
+		});
+	});
+
+	return startedSessions;
+}
+
+suite('Auto attach', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+	const testExeDir = path.join(__dirname, "..", "..", "..", "build", "tests", "bin");
+
+	test('Attach once', async () => {
+
+		const sessions = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: path.join(testExeDir, "caller.exe"),
+			args: [
+				"--init-time", "100",
+				"--final-time", "100",
+				"--wait",
+				path.join(testExeDir, "callee.exe"),
+				"-",
+				"--sleep-time", "200"
+			],
+		});
+
+		assert.strictEqual(sessions.length, 2);
+
+		assert.strictEqual(sessions[0].name, "Parent Session");
+
+		assert.isTrue(sessions[1].name.startsWith("callee.exe #"));
+
+	}).timeout(100000);
+
+	test('Attach recursive', async () => {
+
+		const sessions = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: path.join(testExeDir, "caller.exe"),
+			args: [
+				"--init-time", "100",
+				"--final-time", "100",
+				"--wait",
+				path.join(testExeDir, "caller.exe"),
+				"-",
+				"--init-time", "100",
+				"--final-time", "100",
+				"--wait",
+				path.join(testExeDir, "callee.exe"),
+				"-",
+				"--sleep-time", "200"
+			],
+			"console": "integratedTerminal",
+		});
+
+		// console.log(JSON.stringify(sessions));
+
+		assert.strictEqual(sessions.length, 3);
+
+		assert.strictEqual(sessions[0].name, "Parent Session");
+
+		assert.isTrue(sessions[1].name.startsWith("caller.exe #"));
+
+		assert.isTrue(sessions[2].name.startsWith("callee.exe #"));
+
+	}).timeout(100000);
+
+	test('Attach suspended', async () => {
+
+		const sessions = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: path.join(testExeDir, "caller.exe"),
+			args: [
+				"--init-time", "100",
+				"--suspend-time", "0",
+				"--final-time", "100",
+				"--suspend",
+				"--wait",
+				path.join(testExeDir, "callee.exe"),
+				"-",
+				"--sleep-time", "200"
+			],
+		});
+
+		assert.strictEqual(sessions.length, 2);
+
+		assert.strictEqual(sessions[0].name, "Parent Session");
+
+		assert.isTrue(sessions[1].name.startsWith("callee.exe #"));
+
+	}).timeout(100000);
+
+	test('Attach Only Command Line', async () => {
+
+		const sessions = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: path.join(testExeDir, "caller.exe"),
+			args: [
+				"--init-time", "100",
+				"--final-time", "100",
+				"--no-app-name",
+				"--wait",
+				path.join(testExeDir, "callee.exe"),
+				"-",
+				"--sleep-time", "200"
+			],
+		});
+
+		assert.strictEqual(sessions.length, 2);
+
+		assert.strictEqual(sessions[0].name, "Parent Session");
+
+		assert.isTrue(sessions[1].name.startsWith("callee.exe #"));
+
+	}).timeout(100000);
 });

--- a/vsdbg-engine-extension/tests/callee/main.cpp
+++ b/vsdbg-engine-extension/tests/callee/main.cpp
@@ -1,4 +1,5 @@
 
+#include <cassert>
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -6,11 +7,95 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-int main(int /*argc*/, char* /*argv*/[])
+struct Options
 {
+    std::chrono::seconds sleep_time = std::chrono::seconds(15);
+};
+
+std::string utf16_to_utf8(const std::wstring& input)
+{
+    if(input.empty()) return {};
+
+    const auto result_size = WideCharToMultiByte(CP_UTF8, 0,
+                                                 input.data(), static_cast<int>(input.size()),
+                                                 nullptr, 0,
+                                                 nullptr, nullptr);
+    assert(result_size > 0);
+
+    std::string result(result_size, '\0');
+    const auto  bytes_converted = WideCharToMultiByte(CP_UTF8, 0,
+                                                      input.data(), static_cast<int>(input.size()),
+                                                      result.data(), result_size,
+                                                      nullptr, nullptr);
+    assert(bytes_converted != 0);
+
+    return result;
+}
+
+void print_usage()
+{
+    std::wcout << L"Usage: callee.exe <Options>\n"
+               << L"\n"
+               << L"Options:\n"
+               << L"  --help, -h        Show this help text.\n"
+               << L"  --sleep-time <MS> Time to wait before terminating the app.\n"
+               << L"                    default: 15'000\n";
+}
+
+[[noreturn]] void print_usage_and_exit(int exit_code)
+{
+    print_usage();
+    std::quick_exit(exit_code);
+}
+
+[[noreturn]] void print_error_and_exit(std::wstring_view error)
+{
+    std::wcout << L"Error:\n"
+               << L"  " << error << L"\n\n";
+    print_usage_and_exit(EXIT_FAILURE);
+}
+
+Options parse_command_line(int argc, wchar_t* argv[]) // NOLINT(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+{
+    Options result;
+    bool    help = false;
+    for(int arg_i = 1; arg_i < argc; ++arg_i)
+    {
+        const auto current_arg = std::wstring_view(argv[arg_i]);
+        if(current_arg == L"--help")
+        {
+            help = true;
+        }
+        else if(current_arg == L"--sleep-time")
+        {
+            if(argc <= arg_i + 1) print_error_and_exit(L"Missing argument for --sleep-time.");
+            const auto next_arg = utf16_to_utf8(argv[++arg_i]);
+
+            std::chrono::milliseconds::rep mills;
+
+            auto chars_result = std::from_chars(next_arg.data(), next_arg.data() + next_arg.size(), mills);
+            if(chars_result.ec != std::errc{}) print_error_and_exit(L"Invalid argument for --sleep-time.");
+
+            result.sleep_time = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::milliseconds(mills));
+        }
+    }
+
+    if(help)
+    {
+        print_usage_and_exit(EXIT_SUCCESS);
+    }
+
+    return result;
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
+int wmain(int argc, wchar_t* argv[])
+{
+    const auto opts = parse_command_line(argc, argv);
+
     std::wcout << L"  CALLEE (" << GetCurrentProcessId() << L"): initialized" << std::endl;
 
-    std::this_thread::sleep_for(std::chrono::seconds(15));
+    std::this_thread::sleep_for(opts.sleep_time);
 
     std::wcout << L"  CALLEE (" << GetCurrentProcessId() << L"): terminating" << std::endl;
 


### PR DESCRIPTION
Add some first integration tests.

Includes a fix in the VS Debug Engine Extension for creating the child process data item. Without that fix the debugger could crash when it tried to skip the initial breakpoint.

Resolves #10 