### PR TITLE
Improve tests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ interface EngineSettings {
 	attachOthers: boolean
 }
 
-interface ChildDebuggerConfigurationExtension {
+export interface ChildDebuggerConfigurationExtension {
 	parentProcessId: number;
 	parentThreadId: number;
 	parentSuspended: boolean;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import { ChildDebuggerConfigurationExtension } from '../../extension';
 // import * as myExtension from '../../extension';
 
 async function startDebuggingAndWait(configuration: vscode.DebugConfiguration) {
@@ -25,20 +26,23 @@ async function startDebuggingAndWait(configuration: vscode.DebugConfiguration) {
 		eventEmitter.on('startSession', resolve);
 	});
 
-	// vscode.debug.registerDebugAdapterTrackerFactory('*', {
-	// 	createDebugAdapterTracker(session: vscode.DebugSession) {
-	// 		return {
-	// 			onDidSendMessage: (m) => {
-	// 				if (m.type !== "event" ||
-	// 					m.event !== "output" ||
-	// 					m.body.category !== "console") {
-	// 					return;
-	// 				}
-	// 				console.log(m.body.output);
-	// 			}
-	// 		};
-	// 	}
-	// });
+	var output = "";
+
+	vscode.debug.registerDebugAdapterTrackerFactory('*', {
+		createDebugAdapterTracker(session: vscode.DebugSession) {
+			return {
+				onDidSendMessage: (m) => {
+					if (m.type !== "event" ||
+						m.event !== "output" ||
+						m.body.category !== "stdout") {
+						return;
+					}
+					output += m.body.output;
+					// console.log(m.body.output);
+				}
+			};
+		}
+	});
 
 	await vscode.debug.startDebugging(undefined, configuration);
 
@@ -53,7 +57,7 @@ async function startDebuggingAndWait(configuration: vscode.DebugConfiguration) {
 		});
 	});
 
-	return startedSessions;
+	return { startedSessions, output };
 }
 
 suite('Auto attach', () => {
@@ -61,116 +65,505 @@ suite('Auto attach', () => {
 
 	const testExeDir = path.join(__dirname, "..", "..", "..", "build", "tests", "bin");
 
-	test('Attach once', async () => {
+	const callerPath = path.join(testExeDir, "caller.exe");
+	const calleePath = path.join(testExeDir, "callee.exe");
 
-		const sessions = await startDebuggingAndWait({
+	test('Attach once', async () => {
+		vscode.window.showInformationMessage('RUN Attach once.');
+
+		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
 			name: "Parent Session",
 			request: "launch",
-			program: path.join(testExeDir, "caller.exe"),
+			program: callerPath,
 			args: [
-				"--init-time", "100",
-				"--final-time", "100",
+				"--init-time", "0",
+				"--final-time", "0",
 				"--wait",
-				path.join(testExeDir, "callee.exe"),
+				calleePath,
 				"-",
-				"--sleep-time", "200"
+				"--sleep-time", "0"
 			],
+			"console": "internalConsole",
+		});
+		assert.strictEqual(result.startedSessions.length, 2);
+
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+
+		const childSession = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension.childSuspended);
+		assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+		const cpid = debuggerConfigExtension.childProcessId;
+		const ctid = debuggerConfigExtension.childThreadId;
+		const ppid = debuggerConfigExtension.parentProcessId;
+
+		assert.strictEqual(childSession.name, `callee.exe #${cpid}`);
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid}): initialized\r\n` +
+			`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+			`  CALLER (${ppid}): wait for child\r\n` +
+			`  CALLEE (${cpid}): initialized\r\n` +
+			`  CALLEE (${cpid}): terminating\r\n` +
+			`  CALLER (${ppid}): terminating\r\n`
+		);
+
+	}).timeout(100000);
+
+	test('Attach non existent', async () => {
+		vscode.window.showInformationMessage('RUN non existent.');
+
+		const result = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: callerPath,
+			args: [
+				"--init-time", "0",
+				"--final-time", "0",
+				"--wait",
+				path.join(testExeDir, "does-not-exist.exe"),
+				"-",
+				"--sleep-time", "0"
+			],
+			"console": "internalConsole",
 		});
 
-		assert.strictEqual(sessions.length, 2);
+		assert.strictEqual(result.startedSessions.length, 1);
 
-		assert.strictEqual(sessions[0].name, "Parent Session");
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
-		assert.isTrue(sessions[1].name.startsWith("callee.exe #"));
+		assert.include(result.output, "failed to create child process");
 
 	}).timeout(100000);
 
 	test('Attach recursive', async () => {
+		vscode.window.showInformationMessage('RUN Attach recursive.');
 
-		const sessions = await startDebuggingAndWait({
+		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
 			name: "Parent Session",
 			request: "launch",
-			program: path.join(testExeDir, "caller.exe"),
+			program: callerPath,
 			args: [
-				"--init-time", "100",
-				"--final-time", "100",
+				"--init-time", "0",
+				"--final-time", "0",
 				"--wait",
-				path.join(testExeDir, "caller.exe"),
+				callerPath,
 				"-",
-				"--init-time", "100",
-				"--final-time", "100",
+				"--init-time", "0",
+				"--final-time", "0",
 				"--wait",
-				path.join(testExeDir, "callee.exe"),
+				calleePath,
 				"-",
-				"--sleep-time", "200"
+				"--sleep-time", "0"
 			],
-			"console": "integratedTerminal",
+			"console": "internalConsole",
+			// "console": "integratedTerminal",
 		});
 
 		// console.log(JSON.stringify(sessions));
 
-		assert.strictEqual(sessions.length, 3);
+		assert.strictEqual(result.startedSessions.length, 3);
 
-		assert.strictEqual(sessions[0].name, "Parent Session");
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
-		assert.isTrue(sessions[1].name.startsWith("caller.exe #"));
+		const childSession1 = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession1.configuration);
+		const childSession2 = result.startedSessions[2];
+		assert.isTrue('childDebuggerExtension' in childSession2.configuration);
 
-		assert.isTrue(sessions[2].name.startsWith("callee.exe #"));
+		const debuggerConfigExtension1: ChildDebuggerConfigurationExtension = childSession1.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension1.childSuspended);
+		assert.isTrue(debuggerConfigExtension1.parentSuspended);
+
+		const cpid1 = debuggerConfigExtension1.childProcessId;
+		const ctid1 = debuggerConfigExtension1.childThreadId;
+		const ppid1 = debuggerConfigExtension1.parentProcessId;
+
+		assert.strictEqual(childSession1.name, `caller.exe #${cpid1}`);
+
+		const debuggerConfigExtension2: ChildDebuggerConfigurationExtension = childSession2.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension2.childSuspended);
+		assert.isTrue(debuggerConfigExtension2.parentSuspended);
+
+		const cpid2 = debuggerConfigExtension2.childProcessId;
+		const ctid2 = debuggerConfigExtension2.childThreadId;
+		const ppid2 = debuggerConfigExtension2.parentProcessId;
+		const ptid2 = debuggerConfigExtension2.parentProcessId;
+
+		assert.strictEqual(childSession2.name, `callee.exe #${cpid2}`);
+
+		assert.strictEqual(ppid2, cpid1);
+		// assert.strictEqual(ptid2, ctid1); // We can probably not assume that the main thread starts the child process?
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid1}): initialized\r\n` +
+			`  CALLER (${ppid1}): started process ${callerPath}; PID ${cpid1}; TID ${ctid1}\r\n` +
+			`  CALLER (${ppid1}): wait for child\r\n` +
+			`  CALLER (${cpid1}): initialized\r\n` +
+			`  CALLER (${cpid1}): started process ${calleePath}; PID ${cpid2}; TID ${ctid2}\r\n` +
+			`  CALLER (${cpid1}): wait for child\r\n` +
+			`  CALLEE (${cpid2}): initialized\r\n` +
+			`  CALLEE (${cpid2}): terminating\r\n` +
+			`  CALLER (${cpid1}): terminating\r\n` +
+			`  CALLER (${ppid1}): terminating\r\n`
+		);
 
 	}).timeout(100000);
 
 	test('Attach suspended', async () => {
+		vscode.window.showInformationMessage('RUN Attach suspended.');
 
-		const sessions = await startDebuggingAndWait({
+		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
 			name: "Parent Session",
 			request: "launch",
-			program: path.join(testExeDir, "caller.exe"),
+			program: callerPath,
 			args: [
-				"--init-time", "100",
+				"--init-time", "0",
 				"--suspend-time", "0",
-				"--final-time", "100",
+				"--final-time", "0",
 				"--suspend",
 				"--wait",
-				path.join(testExeDir, "callee.exe"),
+				calleePath,
 				"-",
-				"--sleep-time", "200"
+				"--sleep-time", "0"
 			],
+			"console": "internalConsole",
 		});
 
-		assert.strictEqual(sessions.length, 2);
+		assert.strictEqual(result.startedSessions.length, 2);
 
-		assert.strictEqual(sessions[0].name, "Parent Session");
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
-		assert.isTrue(sessions[1].name.startsWith("callee.exe #"));
+		const childSession = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+		assert.isFalse(debuggerConfigExtension.childSuspended);
+		assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+		const cpid = debuggerConfigExtension.childProcessId;
+		const ctid = debuggerConfigExtension.childThreadId;
+		const ppid = debuggerConfigExtension.parentProcessId;
+
+		assert.isTrue(childSession.name.startsWith(`callee.exe #${cpid}`));
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid}): initialized\r\n` +
+			`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+			`  CALLER (${ppid}): resumed child\r\n` +
+			`  CALLER (${ppid}): wait for child\r\n` +
+			`  CALLEE (${cpid}): initialized\r\n` +
+			`  CALLEE (${cpid}): terminating\r\n` +
+			`  CALLER (${ppid}): terminating\r\n`
+		);
 
 	}).timeout(100000);
 
-	test('Attach Only Command Line', async () => {
+	test('Attach only command line', async () => {
+		vscode.window.showInformationMessage('RUN Attach Only Command Line.');
 
-		const sessions = await startDebuggingAndWait({
+		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
 			name: "Parent Session",
 			request: "launch",
-			program: path.join(testExeDir, "caller.exe"),
+			program: callerPath,
 			args: [
-				"--init-time", "100",
-				"--final-time", "100",
+				"--init-time", "0",
+				"--final-time", "0",
 				"--no-app-name",
 				"--wait",
-				path.join(testExeDir, "callee.exe"),
+				calleePath,
 				"-",
-				"--sleep-time", "200"
+				"--sleep-time", "0"
 			],
+			"console": "internalConsole",
 		});
 
-		assert.strictEqual(sessions.length, 2);
+		assert.strictEqual(result.startedSessions.length, 2);
 
-		assert.strictEqual(sessions[0].name, "Parent Session");
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
-		assert.isTrue(sessions[1].name.startsWith("callee.exe #"));
+		const childSession = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension.childSuspended);
+		assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+		const cpid = debuggerConfigExtension.childProcessId;
+		const ctid = debuggerConfigExtension.childThreadId;
+		const ppid = debuggerConfigExtension.parentProcessId;
+
+		assert.strictEqual(childSession.name, `callee.exe #${cpid}`);
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid}): initialized\r\n` +
+			`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+			`  CALLER (${ppid}): wait for child\r\n` +
+			`  CALLEE (${cpid}): initialized\r\n` +
+			`  CALLEE (${cpid}): terminating\r\n` +
+			`  CALLER (${ppid}): terminating\r\n`
+		);
 
 	}).timeout(100000);
+
+	test('Attach once ANSI', async () => {
+		vscode.window.showInformationMessage('RUN Attach ANSI.');
+
+		const result = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: callerPath,
+			args: [
+				"--init-time", "0",
+				"--final-time", "0",
+				"--ansi",
+				"--wait",
+				calleePath,
+				"-",
+				"--sleep-time", "0"
+			],
+			"console": "internalConsole",
+		});
+
+		assert.strictEqual(result.startedSessions.length, 2);
+
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+
+		const childSession = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension.childSuspended);
+		assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+		const cpid = debuggerConfigExtension.childProcessId;
+		const ctid = debuggerConfigExtension.childThreadId;
+		const ppid = debuggerConfigExtension.parentProcessId;
+
+		assert.strictEqual(childSession.name, `callee.exe #${cpid}`);
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid}): initialized\r\n` +
+			`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+			`  CALLER (${ppid}): wait for child\r\n` +
+			`  CALLEE (${cpid}): initialized\r\n` +
+			`  CALLEE (${cpid}): terminating\r\n` +
+			`  CALLER (${ppid}): terminating\r\n`
+		);
+
+	}).timeout(100000);
+
+	test('Attach only command line ANSI', async () => {
+		vscode.window.showInformationMessage('RUN Attach Only Command Line ANSI.');
+
+		const result = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: callerPath,
+			args: [
+				"--init-time", "0",
+				"--final-time", "0",
+				"--no-app-name",
+				"--ansi",
+				"--wait",
+				calleePath,
+				"-",
+				"--sleep-time", "0"
+			],
+			"console": "internalConsole",
+		});
+
+		assert.strictEqual(result.startedSessions.length, 2);
+
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+
+		const childSession = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension.childSuspended);
+		assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+		const cpid = debuggerConfigExtension.childProcessId;
+		const ctid = debuggerConfigExtension.childThreadId;
+		const ppid = debuggerConfigExtension.parentProcessId;
+
+		assert.strictEqual(childSession.name, `callee.exe #${cpid}`);
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid}): initialized\r\n` +
+			`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+			`  CALLER (${ppid}): wait for child\r\n` +
+			`  CALLEE (${cpid}): initialized\r\n` +
+			`  CALLEE (${cpid}): terminating\r\n` +
+			`  CALLER (${ppid}): terminating\r\n`
+		);
+
+	}).timeout(100000);
+
+	test('Attach once User', async () => {
+		vscode.window.showInformationMessage('RUN Attach user.');
+
+		const result = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: callerPath,
+			args: [
+				"--init-time", "0",
+				"--final-time", "0",
+				"--method", "user",
+				"--wait",
+				calleePath,
+				"-",
+				"--sleep-time", "0"
+			],
+			"console": "internalConsole",
+		});
+
+		assert.strictEqual(result.startedSessions.length, 2);
+
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+
+		const childSession = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension.childSuspended);
+		assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+		const cpid = debuggerConfigExtension.childProcessId;
+		const ctid = debuggerConfigExtension.childThreadId;
+		const ppid = debuggerConfigExtension.parentProcessId;
+
+		assert.strictEqual(childSession.name, `callee.exe #${cpid}`);
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid}): initialized\r\n` +
+			`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+			`  CALLER (${ppid}): wait for child\r\n` +
+			`  CALLEE (${cpid}): initialized\r\n` +
+			`  CALLEE (${cpid}): terminating\r\n` +
+			`  CALLER (${ppid}): terminating\r\n`
+		);
+
+	}).timeout(100000);
+
+	test('Attach once User ANSI', async () => {
+		vscode.window.showInformationMessage('RUN Attach user ANSI.');
+
+		const result = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: callerPath,
+			args: [
+				"--init-time", "0",
+				"--final-time", "0",
+				"--method", "user",
+				"--ansi",
+				"--wait",
+				calleePath,
+				"-",
+				"--sleep-time", "0"
+			],
+			"console": "internalConsole",
+		});
+
+		assert.strictEqual(result.startedSessions.length, 2);
+
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+
+		const childSession = result.startedSessions[1];
+		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+		assert.isTrue(debuggerConfigExtension.childSuspended);
+		assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+		const cpid = debuggerConfigExtension.childProcessId;
+		const ctid = debuggerConfigExtension.childThreadId;
+		const ppid = debuggerConfigExtension.parentProcessId;
+
+		assert.strictEqual(childSession.name, `callee.exe #${cpid}`);
+
+		assert.strictEqual(result.output,
+			`  CALLER (${ppid}): initialized\r\n` +
+			`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+			`  CALLER (${ppid}): wait for child\r\n` +
+			`  CALLEE (${cpid}): initialized\r\n` +
+			`  CALLEE (${cpid}): terminating\r\n` +
+			`  CALLER (${ppid}): terminating\r\n`
+		);
+
+	}).timeout(100000);
+
+	// test('Attach once Token', async () => {
+	// 	vscode.window.showInformationMessage('RUN Attach Token.');
+
+	// 	const result = await startDebuggingAndWait({
+	// 		type: "cppvsdbg",
+	// 		name: "Parent Session",
+	// 		request: "launch",
+	// 		program: callerPath,
+	// 		args: [
+	// 			"--init-time", "0",
+	// 			"--final-time", "0",
+	// 			"--method", "token",
+	// 			"--wait",
+	// 			calleePath,
+	// 			"-",
+	// 			"--sleep-time", "0"
+	// 		],
+	// 		"console": "internalConsole",
+	// 	});
+
+	// 	assert.strictEqual(result.startedSessions.length, 2);
+
+	// 	assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+
+	// 	const childSession = result.startedSessions[1];
+	// 	assert.isTrue('childDebuggerExtension' in childSession.configuration);
+
+	// 	const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+
+	// 	assert.isTrue(debuggerConfigExtension.childSuspended);
+	// 	assert.isTrue(debuggerConfigExtension.parentSuspended);
+
+	// 	const cpid = debuggerConfigExtension.childProcessId;
+	// 	const ctid = debuggerConfigExtension.childThreadId;
+	// 	const ppid = debuggerConfigExtension.parentProcessId;
+
+	// 	assert.strictEqual(childSession.name, `callee.exe #${cpid}`);
+
+	// 	assert.strictEqual(result.output,
+	// 		`  CALLER (${ppid}): initialized\r\n` +
+	// 		`  CALLER (${ppid}): started process ${calleePath}; PID ${cpid}; TID ${ctid}\r\n` +
+	// 		`  CALLER (${ppid}): wait for child\r\n` +
+	// 		`  CALLEE (${cpid}): initialized\r\n` +
+	// 		`  CALLEE (${cpid}): terminating\r\n` +
+	// 		`  CALLER (${ppid}): terminating\r\n`
+	// 	);
+
+	// }).timeout(100000);
+
 });

--- a/vsdbg-engine-extension/tests/CMakeLists.txt
+++ b/vsdbg-engine-extension/tests/CMakeLists.txt
@@ -9,6 +9,10 @@ target_compile_features(caller
     cxx_std_23
 )
 
+target_link_libraries(caller
+  wtsapi32.lib
+)
+
 add_executable(callee
   callee/main.cpp
 )


### PR DESCRIPTION
Introduce some more tests so that we now test all supported process creation methods.

Unfortunately I could not yet get `CreateProcessWithTokenW` and `CreateProcessWithLogonW` working in the "caller" test application yet (they seem to require more privileges). Hence, those methods are not yet supported.

Additionally the tests have been improved by checking that we get all the expected console output from the parent and child processes through the debugger (using `"console": "internalConsole"`). This should ensure that the debugger actually attached correctly to the child process and did stay attached through its entire lifetime.