### PR TITLE
Add support for x86 (32-bit) executable debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,28 +30,47 @@ jobs:
           cmakeVersion: "~3.25.0"
           ninjaVersion: "^1.11.1"
   
-      - uses: TheMrMilchmann/setup-msvc-dev@v2
-        with:
-          arch: x64
-  
       - name: Install VSDbg Engine Extension Dependencies
         run: |
           nuget install Microsoft.VSSDK.Debugger.VSDebugEng -Version 17.0.2012801
           nuget install Microsoft.VSSDK.Debugger.VSDConfigTool -Version 17.0.2012801
-  
-      - name: Configure VSDbg Engine Extension
+
+      - uses: TheMrMilchmann/setup-msvc-dev@v2
+        with:
+          arch: x64
+
+      - name: Configure VSDbg Engine Extension (x64)
         run: |
-          mkdir build
-          cd build
+          mkdir build-x64
+          cd build-x64
           cmake "${{ github.workspace }}\vsdbg-engine-extension" `
           -G Ninja `
           -DCMAKE_BUILD_TYPE=Debug `
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension"
   
-      - name: Build & Install VSDbg Engine Extension
+      - name: Build & Install VSDbg Engine Extension (x64)
         run: |
-          cd build
+          cd build-x64
+          ninja install
+
+      - uses: TheMrMilchmann/setup-msvc-dev@v2
+        with:
+          arch: x86
+
+      - name: Configure VSDbg Engine Extension (x86)
+        run: |
+          mkdir build-x86
+          cd build-x86
+          cmake "${{ github.workspace }}\vsdbg-engine-extension" `
+          -G Ninja `
+          -DCMAKE_BUILD_TYPE=Debug `
+          -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension"
+  
+      - name: Build & Install VSDbg Engine Extension (x86)
+        run: |
+          cd build-x86
           ninja install
 
       - name: Compile VSCode Test Sources

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,35 +36,54 @@ jobs:
           cmakeVersion: "~3.25.0"
           ninjaVersion: "^1.11.1"
   
-      - uses: TheMrMilchmann/setup-msvc-dev@v2
-        with:
-          arch: x64
-  
       - name: Install VSDbg Engine Extension Dependencies
         run: |
           nuget install Microsoft.VSSDK.Debugger.VSDebugEng -Version 17.0.2012801
           nuget install Microsoft.VSSDK.Debugger.VSDConfigTool -Version 17.0.2012801
   
-      - name: Configure VSDbg Engine Extension
+      - uses: TheMrMilchmann/setup-msvc-dev@v2
+        with:
+          arch: x64
+  
+      - name: Configure VSDbg Engine Extension (x64)
         run: |
-          mkdir build
-          cd build
+          mkdir build-x64
+          cd build-x64
           cmake "${{ github.workspace }}\vsdbg-engine-extension" `
           -G Ninja `
           -DCMAKE_BUILD_TYPE=Debug `
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension"
   
-      - name: Build & Install VSDbg Engine Extension
+      - name: Build & Install VSDbg Engine Extension (x64)
         run: |
-          cd build
+          cd build-x64
+          ninja install
+
+      - uses: TheMrMilchmann/setup-msvc-dev@v2
+        with:
+          arch: x86
+  
+      - name: Configure VSDbg Engine Extension (x86)
+        run: |
+          mkdir build-x86
+          cd build-x86
+          cmake "${{ github.workspace }}\vsdbg-engine-extension" `
+          -G Ninja `
+          -DCMAKE_BUILD_TYPE=Debug `
+          -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension"
+  
+      - name: Build & Install VSDbg Engine Extension (x86)
+        run: |
+          cd build-x86
           ninja install
 
       - name: Add build info
         run: |
           "ref:    ${{ github.ref_name }}`n" + `
           "commit: ${{ github.sha }}`n"  + `
-          "date:   $(Get-Date -UFormat '%FT%T%Z' -AsUTC)" | Out-File -Path "${{ github.workspace }}/build/bin/info.txt"
+          "date:   $(Get-Date -UFormat '%FT%T%Z' -AsUTC)" | Out-File -Path "${{ github.workspace }}/build-x64/bin/info.txt"
     
       - name: Package VSIX
         run: |
@@ -82,19 +101,24 @@ jobs:
         with:
           name: childdebugger-win32-x64-tests
           path: |
-            ${{ github.workspace }}/build/tests/bin/caller.exe
-            ${{ github.workspace }}/build/tests/bin/caller.pdb
-            ${{ github.workspace }}/build/tests/bin/callee.exe
-            ${{ github.workspace }}/build/tests/bin/callee.pdb
-            ${{ github.workspace }}/build/bin/info.txt
+            ${{ github.workspace }}/build-x64/tests/bin/caller.exe
+            ${{ github.workspace }}/build-x64/tests/bin/caller.pdb
+            ${{ github.workspace }}/build-x64/tests/bin/callee.exe
+            ${{ github.workspace }}/build-x64/tests/bin/callee.pdb
+            ${{ github.workspace }}/build-x86/tests/bin/caller.exe
+            ${{ github.workspace }}/build-x86/tests/bin/caller.pdb
+            ${{ github.workspace }}/build-x86/tests/bin/callee.exe
+            ${{ github.workspace }}/build-x86/tests/bin/callee.pdb
+            ${{ github.workspace }}/build-x64/bin/info.txt
 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v3
         with:
           name: childdebugger-win32-x64-debug-symbols
           path: |
-            ${{ github.workspace }}/build/bin/ChildDebugger.pdb
-            ${{ github.workspace }}/build/bin/info.txt
+            ${{ github.workspace }}/build-x64/bin/ChildDebugger.pdb
+            ${{ github.workspace }}/build-x86/bin/ChildDebugger.pdb
+            ${{ github.workspace }}/build-x64/bin/info.txt
 
   deploy-head:
     name: "Deploy head"

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 vsdbg-engine-extension/bin/
-build/
+build-*/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,7 +9,13 @@
 
 !dist/*.js
 
-!vsdbg-engine-extension/bin/*.dll
-!vsdbg-engine-extension/bin/*.pdb
+!vsdbg-engine-extension/bin/x86/*.dll
+!vsdbg-engine-extension/bin/x86/*.pdb
+!vsdbg-engine-extension/bin/x64/*.dll
+!vsdbg-engine-extension/bin/x64/*.pdb
+!vsdbg-engine-extension/bin/arm/*.dll
+!vsdbg-engine-extension/bin/arm/*.pdb
+!vsdbg-engine-extension/bin/arm64/*.dll
+!vsdbg-engine-extension/bin/arm64/*.pdb
 !vsdbg-engine-extension/bin/*.vsdconfig
 !vsdbg-engine-extension/info.txt

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -60,16 +60,10 @@ async function startDebuggingAndWait(configuration: vscode.DebugConfiguration) {
 	return { startedSessions, output };
 }
 
-suite('Auto attach', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+function testArchitecture(callerPath: string, calleePath: string, arch: string) {
 
-	const testExeDir = path.join(__dirname, "..", "..", "..", "build", "tests", "bin");
-
-	const callerPath = path.join(testExeDir, "caller.exe");
-	const calleePath = path.join(testExeDir, "callee.exe");
-
-	test('Attach once', async () => {
-		vscode.window.showInformationMessage('RUN Attach once.');
+	test(`Attach once (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach once (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -115,8 +109,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach non existent', async () => {
-		vscode.window.showInformationMessage('RUN non existent.');
+	test(`Attach non existent (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN non existent (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -127,7 +121,7 @@ suite('Auto attach', () => {
 				"--init-time", "0",
 				"--final-time", "0",
 				"--wait",
-				path.join(testExeDir, "does-not-exist.exe"),
+				path.join(__dirname, "does-not-exist.exe"),
 				"-",
 				"--sleep-time", "0"
 			],
@@ -142,8 +136,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach recursive', async () => {
-		vscode.window.showInformationMessage('RUN Attach recursive.');
+	test(`Attach recursive (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach recursive (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -219,8 +213,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach suspended', async () => {
-		vscode.window.showInformationMessage('RUN Attach suspended.');
+	test(`Attach suspended (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach suspended (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -270,8 +264,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach only command line', async () => {
-		vscode.window.showInformationMessage('RUN Attach Only Command Line.');
+	test(`Attach only command line (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach Only Command Line (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -319,8 +313,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach once ANSI', async () => {
-		vscode.window.showInformationMessage('RUN Attach ANSI.');
+	test(`Attach once ANSI (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach ANSI (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -368,8 +362,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach only command line ANSI', async () => {
-		vscode.window.showInformationMessage('RUN Attach Only Command Line ANSI.');
+	test(`Attach only command line ANSI (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach Only Command Line ANSI (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -418,8 +412,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach once User', async () => {
-		vscode.window.showInformationMessage('RUN Attach user.');
+	test(`Attach once User (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach user (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -467,8 +461,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	test('Attach once User ANSI', async () => {
-		vscode.window.showInformationMessage('RUN Attach user ANSI.');
+	test(`Attach once User ANSI (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Attach user ANSI (${arch}).`);
 
 		const result = await startDebuggingAndWait({
 			type: "cppvsdbg",
@@ -517,8 +511,8 @@ suite('Auto attach', () => {
 
 	}).timeout(100000);
 
-	// test('Attach once Token', async () => {
-	// 	vscode.window.showInformationMessage('RUN Attach Token.');
+	// test(`Attach once Token (${arch})`, async () => {
+	// 	vscode.window.showInformationMessage(`RUN Attach Token (${arch}).`);
 
 	// 	const result = await startDebuggingAndWait({
 	// 		type: "cppvsdbg",
@@ -566,4 +560,22 @@ suite('Auto attach', () => {
 
 	// }).timeout(100000);
 
+}
+
+suite('Auto attach x64', () => {
+	const testExeDirX64 = path.join(__dirname, "..", "..", "..", "build-x64", "tests", "bin");
+
+	const callerPathX64 = path.join(testExeDirX64, "caller.exe");
+	const calleePathX64 = path.join(testExeDirX64, "callee.exe");
+
+	testArchitecture(callerPathX64, calleePathX64, "x64");
+});
+
+suite('Auto attach x86', () => {
+	const testExeDirX86 = path.join(__dirname, "..", "..", "..", "build-x86", "tests", "bin");
+
+	const callerPathX86 = path.join(testExeDirX86, "caller.exe");
+	const calleePathX86 = path.join(testExeDirX86, "callee.exe");
+
+	testArchitecture(callerPathX86, calleePathX86, "x86");
 });

--- a/vsdbg-engine-extension/CMakeLists.txt
+++ b/vsdbg-engine-extension/CMakeLists.txt
@@ -42,10 +42,37 @@ configure_vs_debug_extension(
     "${CMAKE_CURRENT_BINARY_DIR}/include"
 )
 
+set(_arch_sub_dir)
+if(MSVC)
+  if("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "X86")
+    set(_arch_sub_dir "x86")
+  elseif("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "x64")
+    set(_arch_sub_dir "x64")
+  elseif("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "ARMV7")
+    set(_arch_sub_dir "arm")
+  elseif("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "ARM64")
+    set(_arch_sub_dir "arm64")
+  endif()
+else()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|AMD64")
+    if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
+      set(_arch_sub_dir "x86")
+    else()
+      set(_arch_sub_dir "x64")
+    endif()
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM64")
+    if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
+      set(_arch_sub_dir "arm")
+    else()
+      set(_arch_sub_dir "arm64")
+    endif()
+  endif()
+endif()
+
 install(
   TARGETS
     ChildDebugger
-  RUNTIME DESTINATION bin
+  RUNTIME DESTINATION "bin/${_arch_sub_dir}"
 )
 
 install(

--- a/vsdbg-engine-extension/CMakeLists.txt
+++ b/vsdbg-engine-extension/CMakeLists.txt
@@ -6,6 +6,8 @@ project(ChildDebuggerExtension VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin")
 
+option(CHILDDEBUGGER_INSTALL_PDB "Install PDB files with the DLLs" OFF)
+
 find_package(VSDebugEng REQUIRED)
 find_package(VSDebugConfigTool REQUIRED)
 
@@ -74,6 +76,14 @@ install(
     ChildDebugger
   RUNTIME DESTINATION "bin/${_arch_sub_dir}"
 )
+if(CHILDDEBUGGER_INSTALL_PDB)
+  install(
+    FILES
+      "$<TARGET_PDB_FILE:ChildDebugger>"
+    DESTINATION "bin/${_arch_sub_dir}"
+    OPTIONAL
+  )
+endif()
 
 install(
   FILES

--- a/vsdbg-engine-extension/cmake/modules/FindVSDebugEng.cmake
+++ b/vsdbg-engine-extension/cmake/modules/FindVSDebugEng.cmake
@@ -43,23 +43,38 @@ find_path(VSDebugEng_INCLUDE_DIR
     inc
 )
 
-set(_find_vsdebugend_lib_path_suffix)
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86")
-  set(_find_vsdebugend_lib_path_suffix "import-lib/x86")
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
-  set(_find_vsdebugend_lib_path_suffix "import-lib/x64")
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
-  set(_find_vsdebugend_lib_path_suffix "import-lib/arm")
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
-  set(_find_vsdebugend_lib_path_suffix "import-lib/arm64")
+set(_arch_sub_dir)
+if(MSVC)
+  if("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "X86")
+    set(_arch_sub_dir "x86")
+  elseif("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "x64")
+    set(_arch_sub_dir "x64")
+  elseif("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "ARMV7")
+    set(_arch_sub_dir "arm")
+  elseif("${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}" STREQUAL "ARM64")
+    set(_arch_sub_dir "arm64")
+  endif()
+else()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|AMD64")
+    if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
+      set(_arch_sub_dir "x86")
+    else()
+      set(_arch_sub_dir "x64")
+    endif()
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM64")
+    if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
+      set(_arch_sub_dir "arm")
+    else()
+      set(_arch_sub_dir "arm64")
+    endif()
+  endif()
 endif()
 
 find_library(VSDebugEng_LIBRARY
   NAMES vsdebugeng
   PATH_SUFFIXES
-    ${_find_vsdebugend_lib_path_suffix}
+    "import-lib/${_arch_sub_dir}"
 )
-unset(_find_vsdebugend_lib_path_suffix)
 
 mark_as_advanced(
   VSDebugEng_INCLUDE_DIR

--- a/vsdbg-engine-extension/src/ChildDebuggerService.cpp
+++ b/vsdbg-engine-extension/src/ChildDebuggerService.cpp
@@ -274,68 +274,199 @@ protected:
 
 struct CreateProcessStack
 {
-    UINT64 return_address;
+#if defined(_X86_) || defined(_ARM_)
+    using ptr_int_t = UINT32;
+#else
+    using ptr_int_t = UINT64;
+#endif
 
-    UINT64 lpApplicationName;    // NOLINT(readability-identifier-naming)
-    UINT64 lpCommandLine;        // NOLINT(readability-identifier-naming)
-    UINT64 lpProcessAttributes;  // NOLINT(readability-identifier-naming)
-    UINT64 lpThreadAttributes;   // NOLINT(readability-identifier-naming)
-    UINT8  bInheritHandles;      // NOLINT(readability-identifier-naming)
-    UINT8  Padding1;             // NOLINT(readability-identifier-naming)
-    UINT16 Padding2;             // NOLINT(readability-identifier-naming)
-    UINT32 Padding3;             // NOLINT(readability-identifier-naming)
-    UINT32 dwCreationFlags;      // NOLINT(readability-identifier-naming)
-    UINT32 Padding4;             // NOLINT(readability-identifier-naming)
-    UINT64 lpEnvironment;        // NOLINT(readability-identifier-naming)
-    UINT64 lpCurrentDirectory;   // NOLINT(readability-identifier-naming)
-    UINT64 lpStartupInfo;        // NOLINT(readability-identifier-naming)
-    UINT64 lpProcessInformation; // NOLINT(readability-identifier-naming)
+    ptr_int_t return_address;
 
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static DWORD64 get_lpApplicationName_from_register(const CONTEXT& context)
+    ptr_int_t lpApplicationName;   // NOLINT(readability-identifier-naming)
+    ptr_int_t lpCommandLine;       // NOLINT(readability-identifier-naming)
+    ptr_int_t lpProcessAttributes; // NOLINT(readability-identifier-naming)
+    ptr_int_t lpThreadAttributes;  // NOLINT(readability-identifier-naming)
+    UINT8     bInheritHandles;     // NOLINT(readability-identifier-naming)
+    UINT8     Padding1;            // NOLINT(readability-identifier-naming)
+    UINT16    Padding2;            // NOLINT(readability-identifier-naming)
+#if defined(_AMD64_) || defined(_ARM64_)
+    UINT32 Padding3; // NOLINT(readability-identifier-naming)
+#endif
+    UINT32 dwCreationFlags; // NOLINT(readability-identifier-naming)
+#if defined(_AMD64_) || defined(_ARM64_)
+    // UINT32       Padding4;             // NOLINT(readability-identifier-naming)
+#endif
+    ptr_int_t lpEnvironment;        // NOLINT(readability-identifier-naming)
+    ptr_int_t lpCurrentDirectory;   // NOLINT(readability-identifier-naming)
+    ptr_int_t lpStartupInfo;        // NOLINT(readability-identifier-naming)
+    ptr_int_t lpProcessInformation; // NOLINT(readability-identifier-naming)
+
+    // NOLINTNEXTLINE(readability-identifier-naming, readability-convert-member-functions-to-static)
+    [[nodiscard]] ptr_int_t get_lpApplicationName([[maybe_unused]] const CONTEXT& context) const
     {
+#if defined(_X86_)
+        return lpApplicationName;
+#elif defined(_AMD64_)
         return context.Rcx;
+#elif defined(_ARM_)
+        return context.R9;
+#elif defined(_ARM64_)
+        return context.X9;
+#endif
     }
 
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static DWORD64 get_lpCommandLine_from_register(const CONTEXT& context)
+    // NOLINTNEXTLINE(readability-identifier-naming, readability-convert-member-functions-to-static)
+    [[nodiscard]] ptr_int_t get_lpCommandLine([[maybe_unused]] const CONTEXT& context) const
     {
+#if defined(_X86_)
+        return lpCommandLine;
+#elif defined(_AMD64_)
         return context.Rdx;
+#elif defined(_ARM_)
+        return context.R1;
+#elif defined(_ARM64_)
+        return context.X0;
+#endif
+    }
+
+    // NOLINTNEXTLINE(readability-identifier-naming, readability-convert-member-functions-to-static)
+    [[nodiscard]] DWORD64 get_lpProcessInformation([[maybe_unused]] const CONTEXT& context) const
+    {
+#if defined(_X86_)
+        return lpProcessInformation;
+#elif defined(_AMD64_)
+        return lpProcessInformation;
+#elif defined(_ARM_)
+        return context.R2;
+#elif defined(_ARM64_)
+        return context.X2;
+#endif
+    }
+
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    [[nodiscard]] DWORD64 get_return_address([[maybe_unused]] const CONTEXT& context) const
+    {
+#if defined(_X86_) || defined(_AMD64_)
+        return return_address;
+#elif defined(_ARM_)
+        return context.Lr;
+#elif defined(_ARM64_)
+        return context.Lr;
+#endif
     }
 };
 
 struct CreateProcessAsUserStack
 {
-    UINT64 return_address; // NOLINT(readability-identifier-naming)
+#if defined(_X86_) || defined(_ARM_)
+    using ptr_int_t = UINT32;
+#else
+    using ptr_int_t = UINT64;
+#endif
 
-    UINT64 hToken; // NOLINT(readability-identifier-naming)
+    ptr_int_t return_address; // NOLINT(readability-identifier-naming)
 
-    UINT64 lpApplicationName;    // NOLINT(readability-identifier-naming)
-    UINT64 lpCommandLine;        // NOLINT(readability-identifier-naming)
-    UINT64 lpProcessAttributes;  // NOLINT(readability-identifier-naming)
-    UINT64 lpThreadAttributes;   // NOLINT(readability-identifier-naming)
-    UINT8  bInheritHandles;      // NOLINT(readability-identifier-naming)
-    UINT8  Padding1;             // NOLINT(readability-identifier-naming)
-    UINT16 Padding2;             // NOLINT(readability-identifier-naming)
-    UINT32 Padding3;             // NOLINT(readability-identifier-naming)
-    UINT32 dwCreationFlags;      // NOLINT(readability-identifier-naming)
-    UINT32 Padding4;             // NOLINT(readability-identifier-naming)
-    UINT64 lpEnvironment;        // NOLINT(readability-identifier-naming)
-    UINT64 lpCurrentDirectory;   // NOLINT(readability-identifier-naming)
-    UINT64 lpStartupInfo;        // NOLINT(readability-identifier-naming)
-    UINT64 lpProcessInformation; // NOLINT(readability-identifier-naming)
+    ptr_int_t hToken; // NOLINT(readability-identifier-naming)
 
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static DWORD64 get_lpApplicationName_from_register(const CONTEXT& context)
+    ptr_int_t lpApplicationName;   // NOLINT(readability-identifier-naming)
+    ptr_int_t lpCommandLine;       // NOLINT(readability-identifier-naming)
+    ptr_int_t lpProcessAttributes; // NOLINT(readability-identifier-naming)
+    ptr_int_t lpThreadAttributes;  // NOLINT(readability-identifier-naming)
+    UINT8     bInheritHandles;     // NOLINT(readability-identifier-naming)
+    UINT8     Padding1;            // NOLINT(readability-identifier-naming)
+    UINT16    Padding2;            // NOLINT(readability-identifier-naming)
+#if defined(_AMD64_) || defined(_ARM64_)
+    UINT32 Padding3; // NOLINT(readability-identifier-naming)
+#endif
+    UINT32 dwCreationFlags; // NOLINT(readability-identifier-naming)
+#if defined(_AMD64_) || defined(_ARM64_)
+    UINT32 Padding4; // NOLINT(readability-identifier-naming)
+#endif
+    ptr_int_t lpEnvironment;        // NOLINT(readability-identifier-naming)
+    ptr_int_t lpCurrentDirectory;   // NOLINT(readability-identifier-naming)
+    ptr_int_t lpStartupInfo;        // NOLINT(readability-identifier-naming)
+    ptr_int_t lpProcessInformation; // NOLINT(readability-identifier-naming)
+
+    // NOLINTNEXTLINE(readability-identifier-naming, readability-convert-member-functions-to-static)
+    [[nodiscard]] DWORD64 get_lpApplicationName([[maybe_unused]] const CONTEXT& context) const
     {
+#if defined(_X86_)
+        return lpApplicationName;
+#elif defined(_AMD64_)
         return context.Rdx;
+#elif defined(_ARM_)
+        return context.R1;
+#elif defined(_ARM64_)
+        return context.X1;
+#endif
     }
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static DWORD64 get_lpCommandLine_from_register(const CONTEXT& context)
+
+    // NOLINTNEXTLINE(readability-identifier-naming, readability-convert-member-functions-to-static)
+    [[nodiscard]] DWORD64 get_lpCommandLine([[maybe_unused]] const CONTEXT& context) const
     {
+#if defined(_X86_)
+        return lpCommandLine;
+#elif defined(_AMD64_)
         return context.R8;
+#elif defined(_ARM_)
+        return context.R2;
+#elif defined(_ARM64_)
+        return context.X2;
+#endif
+    }
+
+    // NOLINTNEXTLINE(readability-identifier-naming, readability-convert-member-functions-to-static)
+    [[nodiscard]] DWORD64 get_lpProcessInformation([[maybe_unused]] const CONTEXT& context) const
+    {
+#if defined(_X86_)
+        return lpProcessInformation;
+#elif defined(_AMD64_)
+        return lpProcessInformation;
+#elif defined(_ARM_)
+        return lpProcessInformation;
+#elif defined(_ARM64_)
+        return lpProcessInformation;
+#endif
+    }
+
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    [[nodiscard]] DWORD64 get_return_address([[maybe_unused]] const CONTEXT& context) const
+    {
+#if defined(_X86_) || defined(_AMD64_)
+        return return_address;
+#elif defined(_ARM_)
+        return context.Lr;
+#elif defined(_ARM64_)
+        return context.Lr;
+#endif
     }
 };
+
+[[nodiscard]] inline auto get_stack_pointer(const CONTEXT& context)
+{
+#if defined(_X86_)
+    return context.Esp;
+#elif defined(_AMD64_)
+    return context.Rsp;
+#elif defined(_ARM_)
+    return context.Sp;
+#elif defined(_ARM64_)
+    return context.Sp;
+#endif
+}
+
+[[nodiscard]] inline auto get_return_value(const CONTEXT& context)
+{
+#if defined(_X86_)
+    return context.Eax;
+#elif defined(_AMD64_)
+    return context.Rax;
+#elif defined(_ARM_)
+    return context.R0;
+#elif defined(_ARM64_)
+    return context.X0;
+#endif
+}
 
 // TODO: add parameter stack definitions for `CreateProcessWithToken` and `CreateProcessWithLogon`.
 
@@ -423,11 +554,24 @@ HRESULT handle_call_to_create_process(
     const CONTEXT&               context,
     bool                         is_unicode)
 {
+    const auto stack_pointer = get_stack_pointer(context);
+    // The other function arguments are passed on the stack, hence we need to extract it.
+    // Assuming x64 calling conventions, the pointer to the stack frame is stored in the
+    // RSP register.
+    StackType  stack;
+    if(thread->Process()->ReadMemory(stack_pointer, DkmReadMemoryFlags::None, &stack, sizeof(StackType), nullptr) != S_OK)
+    {
+        log_file << "  FAILED to read stack.\n";
+        log_file.flush();
+        return S_FALSE;
+    }
+    log_file << "  dwCreationFlags=" << stack.dwCreationFlags << "\n";
+
     // Extract the application name from the passed arguments.
     // Assuming x64 calling conventions, the pointer to the string in memory is stored in the
     // RCX register for `CreateProcessA` and `CreateProcessW`.
     CComPtr<DkmString> application_name;
-    if(read_string_from_memory_at(thread->Process(), StackType::get_lpApplicationName_from_register(context), is_unicode, application_name) != S_OK)
+    if(read_string_from_memory_at(thread->Process(), stack.get_lpApplicationName(context), is_unicode, application_name) != S_OK)
     {
         log_file << "  FAILED to read application name argument.\n";
         log_file.flush();
@@ -443,7 +587,7 @@ HRESULT handle_call_to_create_process(
     // Assuming x64 calling conventions, the pointer to the string in memory is stored in the
     // RDX register for `CreateProcessA` and `CreateProcessW`.
     CComPtr<DkmString> command_line;
-    if(read_string_from_memory_at(thread->Process(), StackType::get_lpCommandLine_from_register(context), is_unicode, command_line) != S_OK)
+    if(read_string_from_memory_at(thread->Process(), stack.get_lpCommandLine(context), is_unicode, command_line) != S_OK)
     {
         log_file << "  FAILED to read command line argument.\n";
         log_file.flush();
@@ -456,18 +600,6 @@ HRESULT handle_call_to_create_process(
     }
 
     if(!check_attach_to_process(settings, log_file, application_name, command_line)) return S_OK;
-
-    // The other function arguments are passed on the stack, hence we need to extract it.
-    // Assuming x64 calling conventions, the pointer to the stack frame is stored in the
-    // RSP register.
-    StackType stack;
-    if(thread->Process()->ReadMemory(context.Rsp, DkmReadMemoryFlags::None, &stack, sizeof(StackType), nullptr) != S_OK)
-    {
-        log_file << "  FAILED to read stack.\n";
-        log_file.flush();
-        return S_FALSE;
-    }
-    log_file << "  dwCreationFlags=" << stack.dwCreationFlags << "\n";
 
     // If want to suspend the child process and it is not already requested to be suspended
     // originally, we enforce a suspended process creation.
@@ -485,7 +617,7 @@ HRESULT handle_call_to_create_process(
         CAutoDkmArray<BYTE> new_flags_bytes;
         DkmAllocArray(sizeof(stack.dwCreationFlags), &new_flags_bytes);
         memcpy(new_flags_bytes.Members, &new_flags, sizeof(stack.dwCreationFlags));
-        if(thread->Process()->WriteMemory(context.Rsp + offsetof(StackType, dwCreationFlags), new_flags_bytes) != S_OK)
+        if(thread->Process()->WriteMemory(stack_pointer + offsetof(StackType, dwCreationFlags), new_flags_bytes) != S_OK)
         {
             log_file << "  FAILED to force suspended start.\n";
             log_file.flush();
@@ -501,18 +633,18 @@ HRESULT handle_call_to_create_process(
     }
 
     // Now, retrieve the return address for this function call.
-    UINT64 return_address;
-    UINT64 frame_base;
-    UINT64 vframe;
-    if(thread->GetCurrentFrameInfo(&return_address, &frame_base, &vframe) != S_OK)
-    {
-        log_file << "  FAILED to retrieve function return address.\n";
-        log_file.flush();
-        return S_FALSE;
-    }
+    // UINT64 return_address;
+    // UINT64 frame_base;
+    // UINT64 vframe;
+    // if(thread->GetCurrentFrameInfo(&return_address, &frame_base, &vframe) != S_OK)
+    // {
+    //     log_file << "  FAILED to retrieve function return address.\n";
+    //     log_file.flush();
+    //     return S_FALSE;
+    // }
 
     CComPtr<DkmInstructionAddress> address;
-    if(thread->Process()->CreateNativeInstructionAddress(return_address, &address) != S_OK)
+    if(thread->Process()->CreateNativeInstructionAddress(stack.get_return_address(context), &address) != S_OK)
     {
         log_file << "  FAILED to create native instruction address from function return address.\n";
         log_file.flush();
@@ -521,7 +653,7 @@ HRESULT handle_call_to_create_process(
 
     // Create a new breakpoint to be triggered when the child process creation is done.
     CComPtr<CreateOutInfo> out_info;
-    out_info.Attach(new CreateOutInfo(stack.lpProcessInformation, forced_suspension));
+    out_info.Attach(new CreateOutInfo(stack.get_lpProcessInformation(context), forced_suspension));
 
     CComPtr<Breakpoints::DkmRuntimeInstructionBreakpoint> breakpoint;
     if(Breakpoints::DkmRuntimeInstructionBreakpoint::Create(source_id, nullptr, address, false, out_info, &breakpoint) != S_OK)
@@ -911,8 +1043,8 @@ HRESULT STDMETHODCALLTYPE CChildDebuggerService::OnRuntimeBreakpoint(
         }
 
         // The RAX register holds the return value.
-        log_file_ << "  CreateProcess returned " << context.Rax << "\n";
-        if(context.Rax == 0)
+        log_file_ << "  CreateProcess returned " << get_return_value(context) << "\n";
+        if(get_return_value(context) == 0)
         {
             // Nothing to attach to if the CreateProcess call failed.
             log_file_.flush();


### PR DESCRIPTION
Adds support for attaching to children of x86 (32-bit) processes. To make this work we mainly needed to implement the calling conventions for x86 `__stdcall`. Additionally the calling conventions for ARM and ARM64 have been implemented, but since I am lacking an ARM machine, these where not tested and hence are not enabled in CI builds.

The `vsix` package does now include two binaries (one for x64 and one for x86), which are picked up by the debug engine depending on what kind of process is being debugged.

Resolves #12 