### PR TITLE
Require opt-in into child processes debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Child Process Debugger for VS Code
 
-A VS Code extension to support (Windows) child process debugging in Visual Studio Code via the `cppvsdbg` Debug Adapter. If installed, it will automatically attach a debugger to all child processes spawned by any process that is currently being debugged.
+A VS Code extension to support (Windows) child process debugging in Visual Studio Code via the `cppvsdbg` Debug Adapter. If installed, adding `"autoAttachChildProcess": true` to your debug launch configuration will make VS Code automatically attach a debugger to all child processes spawned by any process that is currently being debugged.
 
 It is intended to be the VS Code equivalent of the [Microsoft Child Process Debugging Power Tool](https://marketplace.visualstudio.com/items?itemName=vsdbgplat.MicrosoftChildProcessDebuggingPowerTool2022).
 
@@ -16,6 +16,10 @@ It is intended to be the VS Code equivalent of the [Microsoft Child Process Debu
   - it does not proceed and generates some unexpected behavior (e.g. a parent process that original creates a suspended child process could resume it before we had a change to attach the debugger).
 - Recursively attaches to child processes of child processes.
 - Filtering of processes to attach to by the executable name or the command line they are invoked with.
+
+## Limitations
+
+- Only supports the `cppvsdbg` Debug Adapter on Windows. Other platforms or debug adapters are not supported.
 
 ## Installation
 
@@ -41,6 +45,21 @@ Loading extensions from 'C:\Users\[User]\.vscode\extensions\albertziegenhagel-ch
 ```
 
 in the beginning of the `DEBUG CONSOLE` output view when debugging any native application through the C++ `cppvsdbg` debugger.
+
+## Usage
+
+By default, child processes debugging is disabled to make the impact of this extension on the usual debugging experience as small as possible. To enable it, you have to add `"autoAttachChildProcess": true` to the debug configuration in your `launch.json`. E.g. this could look like this:
+
+```json
+{
+    "name": "Debug With Child Processes",
+    "type": "cppvsdbg",
+    "request": "launch",
+    "program": "C:\\Path\\To\\My\\Executable.exe",
+    "cwd": "${workspaceRoot}",
+    "autoAttachChildProcess": true,
+},
+```
 
 ## Dependencies
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
             "order": 0,
             "type": "boolean",
             "default": true,
-            "description": "Enable/disable debugging child processes."
+            "description": "If false, debugging child processes is completely disabled."
           },
           "childDebugger.general.suspendChildren": {
             "order": 1,
@@ -82,6 +82,33 @@
             "type": "boolean",
             "default": true,
             "description": "Whether to attach to any processes that did not match any of the explicit child process filters."
+          }
+        }
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "cppvsdbg",
+        "configurationAttributes": {
+          "launch": {
+            "type": "object",
+            "properties": {
+              "autoAttachChildProcess": {
+                "type": "boolean",
+                "description": "Optional parameter. If true, the debugger will automatically (and recursively) attach to child processes of the target process. This is subject to global child process debugging settings which can completely disable child process debugging or specify filters on which processes to attach to.",
+                "default": false
+              }
+            }
+          },
+          "attach": {
+            "type": "object",
+            "properties": {
+              "autoAttachChildProcess": {
+                "type": "boolean",
+                "description": "Optional parameter. If true, the debugger will automatically (and recursively) attach to child processes of the target process. This is subject to global child process debugging settings which can completely disable child process debugging or specify filters on which processes to attach to.",
+                "default": false
+              }
+            }
           }
         }
       }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -81,16 +81,17 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 		assert.strictEqual(result.startedSessions.length, 2);
 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension.childSuspended);
 		assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -112,6 +113,53 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 
 	}).timeout(100000);
 
+	test(`No attach (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN No attach (${arch}).`);
+
+		const result = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: callerPath,
+			args: [
+				"--init-time", "0",
+				"--final-time", "0",
+				"--wait",
+				calleePath,
+				"-",
+				"--sleep-time", "0"
+			],
+			console: "internalConsole"
+		});
+		assert.strictEqual(result.startedSessions.length, 1);
+
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+	}).timeout(100000);
+
+	test(`Disabled attach (${arch})`, async () => {
+		vscode.window.showInformationMessage(`RUN Disabled attach (${arch}).`);
+
+		const result = await startDebuggingAndWait({
+			type: "cppvsdbg",
+			name: "Parent Session",
+			request: "launch",
+			program: callerPath,
+			args: [
+				"--init-time", "0",
+				"--final-time", "0",
+				"--wait",
+				calleePath,
+				"-",
+				"--sleep-time", "0"
+			],
+			console: "internalConsole",
+			autoAttachChildProcess: false,
+		});
+		assert.strictEqual(result.startedSessions.length, 1);
+
+		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
+	}).timeout(100000);
+
 	test(`Attach non existent (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN non existent (${arch}).`);
 
@@ -128,7 +176,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		assert.strictEqual(result.startedSessions.length, 1);
@@ -160,8 +209,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
-			// "console": "integratedTerminal",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		// console.log(JSON.stringify(sessions));
@@ -171,11 +220,11 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession1 = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession1.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession1.configuration);
 		const childSession2 = result.startedSessions[2];
-		assert.isTrue('childDebuggerExtension' in childSession2.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession2.configuration);
 
-		const debuggerConfigExtension1: ChildDebuggerConfigurationExtension = childSession1.configuration.childDebuggerExtension;
+		const debuggerConfigExtension1: ChildDebuggerConfigurationExtension = childSession1.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension1.childSuspended);
 		assert.isTrue(debuggerConfigExtension1.parentSuspended);
@@ -186,7 +235,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 
 		assert.strictEqual(childSession1.name, `caller.exe #${cpid1}`);
 
-		const debuggerConfigExtension2: ChildDebuggerConfigurationExtension = childSession2.configuration.childDebuggerExtension;
+		const debuggerConfigExtension2: ChildDebuggerConfigurationExtension = childSession2.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension2.childSuspended);
 		assert.isTrue(debuggerConfigExtension2.parentSuspended);
@@ -234,7 +283,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		assert.strictEqual(result.startedSessions.length, 2);
@@ -242,9 +292,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 		assert.isFalse(debuggerConfigExtension.childSuspended);
 		assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -284,7 +334,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		assert.strictEqual(result.startedSessions.length, 2);
@@ -292,9 +343,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension.childSuspended);
 		assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -333,7 +384,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		assert.strictEqual(result.startedSessions.length, 2);
@@ -341,9 +393,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension.childSuspended);
 		assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -383,7 +435,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		assert.strictEqual(result.startedSessions.length, 2);
@@ -391,9 +444,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension.childSuspended);
 		assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -432,7 +485,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		assert.strictEqual(result.startedSessions.length, 2);
@@ -440,9 +494,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension.childSuspended);
 		assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -482,7 +536,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				"-",
 				"--sleep-time", "0"
 			],
-			"console": "internalConsole",
+			console: "internalConsole",
+			autoAttachChildProcess: true,
 		});
 
 		assert.strictEqual(result.startedSessions.length, 2);
@@ -490,9 +545,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 		const childSession = result.startedSessions[1];
-		assert.isTrue('childDebuggerExtension' in childSession.configuration);
+		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 		assert.isTrue(debuggerConfigExtension.childSuspended);
 		assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -533,7 +588,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 					"-",
 					"--sleep-time", "0"
 				],
-				"console": "internalConsole",
+				console: "internalConsole",
+				autoAttachChildProcess: true,
 			});
 
 			assert.strictEqual(result.startedSessions.length, 2);
@@ -541,9 +597,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 			const childSession = result.startedSessions[1];
-			assert.isTrue('childDebuggerExtension' in childSession.configuration);
+			assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-			const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+			const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 			assert.isTrue(debuggerConfigExtension.childSuspended);
 			assert.isTrue(debuggerConfigExtension.parentSuspended);
@@ -586,7 +642,8 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 						"-",
 						"--sleep-time", "0"
 					],
-					"console": "internalConsole",
+					console: "internalConsole",
+					autoAttachChildProcess: true,
 				});
 
 				assert.strictEqual(result.startedSessions.length, 2);
@@ -594,9 +651,9 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				assert.strictEqual(result.startedSessions[0].name, "Parent Session");
 
 				const childSession = result.startedSessions[1];
-				assert.isTrue('childDebuggerExtension' in childSession.configuration);
+				assert.isTrue('_childDebuggerExtension' in childSession.configuration);
 
-				const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration.childDebuggerExtension;
+				const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 
 				assert.isTrue(debuggerConfigExtension.childSuspended);
 				assert.isTrue(debuggerConfigExtension.parentSuspended);

--- a/vsdbg-engine-extension/src/ChildDebuggerService.hpp
+++ b/vsdbg-engine-extension/src/ChildDebuggerService.hpp
@@ -24,12 +24,12 @@ struct ProcessConfig
 
 struct ChildDebuggerSettings
 {
-    bool enabled = false;
-
     bool suspend_children = true;
     bool suspend_parents  = true;
 
     bool skip_initial_breakpoint = true;
+
+    bool attach_any = true;
 
     std::vector<ProcessConfig> process_configs;
     bool                       attach_others = true;
@@ -76,8 +76,13 @@ public:
         _In_ Microsoft::VisualStudio::Debugger::DkmEventDescriptorS* event_descriptor) override;
 
 private:
-    ChildDebuggerSettings                                                settings_;
-    std::ofstream                                                        log_file_;
+    // By default, this extension is dormant and does nothing.
+    // Only when we received valid settings, it will be enabled.
+    bool enabled_ = false;
+
+    ChildDebuggerSettings settings_;
+    std::ofstream         log_file_;
+
     std::array<CComPtr<Microsoft::VisualStudio::Debugger::DkmString>, 6> create_process_function_names_;
 };
 


### PR DESCRIPTION
Changes the debug engine extension to be disabled/dormant by default. It will only do something at all, if it receives settings from the vscode extension.

Additionally a user facing option was added to enable child processes debugging. By default, child processes debugging is disabled now and the user need to set `autoAttachChildProcess` in the debug launch or attach config to enable child process debugging.

Resolves #23 