### PR TITLE
Fix use-after-free related to DataItems for breakpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           cd build/x64
           cmake "${{ github.workspace }}\vsdbg-engine-extension" `
           -G Ninja `
-          -DCMAKE_BUILD_TYPE=Debug `
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo `
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension" `
           -DCHILDDEBUGGER_INSTALL_PDB=ON
@@ -70,7 +70,7 @@ jobs:
           cd build/x86
           cmake "${{ github.workspace }}\vsdbg-engine-extension" `
           -G Ninja `
-          -DCMAKE_BUILD_TYPE=Debug `
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo `
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension" `
           -DCHILDDEBUGGER_INSTALL_PDB=ON

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -51,7 +51,7 @@ jobs:
           cd build/x64
           cmake "${{ github.workspace }}\vsdbg-engine-extension" `
           -G Ninja `
-          -DCMAKE_BUILD_TYPE=Debug `
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo `
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension" `
           -DCHILDDEBUGGER_INSTALL_PDB=ON
@@ -71,7 +71,7 @@ jobs:
           cd build/x86
           cmake "${{ github.workspace }}\vsdbg-engine-extension" `
           -G Ninja `
-          -DCMAKE_BUILD_TYPE=Debug `
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo `
           -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
           -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension" `
           -DCHILDDEBUGGER_INSTALL_PDB=ON


### PR DESCRIPTION
Fixes a use-after-free bug, due to incorrect construction of ComObjects for the `CreateIn/OutInfo` data-items, that made the debugger crash.
This bug was not triggered in debug mode (for some unknown reason, it is UB after all) which is why it did not fail in CI, but then lead to problems in the released binaries.
CI was changed to use the same build type as the released binaries, so that similar errors should be caught in the future.
