### PR TITLE
Allow natvis visualization in child sessions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,8 +130,9 @@ export function activate(context: vscode.ExtensionContext) {
 						_childDebuggerExtension: configurationExtension,
 						// always attach to children of children
 						autoAttachChildProcess: true,
+						visualizerFile: session.configuration.visualizerFile,
 						// TODO: should we copy other configuration properties (like `symbolOptions`)
-						//       from the parent to the child?
+						//       from the parent to the child?,
 					};
 					const options: vscode.DebugSessionOptions = {
 						parentSession: session,

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -83,6 +83,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			],
 			console: "internalConsole",
 			autoAttachChildProcess: true,
+			visualizerFile: "parent.natvis",
 		});
 		assert.strictEqual(result.startedSessions.length, 2);
 
@@ -90,6 +91,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 
 		const childSession = result.startedSessions[1];
 		assert.isTrue('_childDebuggerExtension' in childSession.configuration);
+		assert.strictEqual(childSession.configuration.visualizerFile, "parent.natvis");
 
 		const debuggerConfigExtension: ChildDebuggerConfigurationExtension = childSession.configuration._childDebuggerExtension;
 


### PR DESCRIPTION
closes #35 
Passing visualizerFile parameter to children

As suggested by the TODO comment, other parameters could probably be usefull too