### PR TITLE
Improve CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
 on:
-  push
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,7 +1,10 @@
 name: Package
 
 on:
-  push
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## [Unreleased]
+
 ## 1.2.0
 
 - Fixed an issue where the debugger got confused when multiple threads of a parent process started child processes at nearly the same time. This could manifest itself in the process picker launching is VS Code ([#30](https://github.com/albertziegenhagel/childdebugger-vscode/pull/30)).

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Albert Ziegenhagel",
   "publisher": "albertziegenhagel",
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/albertziegenhagel/childdebugger-vscode",
   "bugs": {
     "url": "https://github.com/albertziegenhagel/childdebugger-vscode/issues"


### PR DESCRIPTION
Trigger build and package workflows on pull requests and pushes to main. Hopefully this fixes triggering on PRs from third party people that I need to approve before they start running.