### PR TITLE
Enable building for ARM64 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,31 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.run-on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        run-on: [windows-latest, windows-11-arm]
+        node-version: [any]
+        include:
+          - run-on: windows-latest
+            node-version: 18.17
+          - run-on: windows-11-arm
+            node-version: 20
+        exclude:
+          - node-version: any
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.17
+          node-version: ${{ matrix.node-version }}
 
       - name: Create Test User
         run: |
+          Import-Module Microsoft.PowerShell.LocalAccounts -UseWindowsPowerShell
           $PW = "Rb4Z7X9d(pf$%*?S=dG@VaMZe" | ConvertTo-SecureString  -AsPlainText -Force
           New-LocalUser -Name "TestUser" -Password $PW
 
@@ -42,6 +56,29 @@ jobs:
         run: |
           nuget install Microsoft.VSSDK.Debugger.VSDebugEng -Version 17.0.2012801
           nuget install Microsoft.VSSDK.Debugger.VSDConfigTool -Version 17.0.2012801
+
+      - uses: TheMrMilchmann/setup-msvc-dev@v3
+        if: matrix.run-on == 'windows-11-arm'
+        with:
+          arch: arm64
+
+      - name: Configure VSDbg Engine Extension (arm64)
+        if: matrix.run-on == 'windows-11-arm'
+        run: |
+          mkdir build/arm64
+          cd build/arm64
+          cmake "${{ github.workspace }}\vsdbg-engine-extension" `
+          -G Ninja `
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+          -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension" `
+          -DCHILDDEBUGGER_INSTALL_PDB=ON
+  
+      - name: Build & Install VSDbg Engine Extension (arm64)
+        if: matrix.run-on == 'windows-11-arm'
+        run: |
+          cd build/arm64
+          ninja install
 
       - uses: TheMrMilchmann/setup-msvc-dev@v3
         with:

--- a/.github/workflows/deploy-head.yml
+++ b/.github/workflows/deploy-head.yml
@@ -64,14 +64,14 @@ jobs:
     if: needs.check.outputs.is_newer == 1
 
     steps:
-      - name: Download build artifact (vsix)
+      - name: Download build artifact (vsix, x64)
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: package.yml
           run_id: ${{ github.event.workflow_run.id }}
           name: childdebugger-win32-x64
 
-      - name: Download build artifacts (tests)
+      - name: Download build artifacts (tests, x64)
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: package.yml
@@ -79,7 +79,7 @@ jobs:
           name: childdebugger-win32-x64-tests
           skip_unpack: true
 
-      - name: Download build artifacts (debug symbols)
+      - name: Download build artifacts (debug symbols, x64)
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: package.yml
@@ -87,7 +87,30 @@ jobs:
           name: childdebugger-win32-x64-debug-symbols
           skip_unpack: true
 
-      - name: Upload release asset (vsix)
+      - name: Download build artifact (vsix, arm64)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: package.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: childdebugger-win32-arm64
+
+      - name: Download build artifacts (tests, arm64)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: package.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: childdebugger-win32-arm64-tests
+          skip_unpack: true
+
+      - name: Download build artifacts (debug symbols, arm64)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: package.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: childdebugger-win32-arm64-debug-symbols
+          skip_unpack: true
+
+      - name: Upload release asset (vsix, x64)
         shell: pwsh
         run: |
           $assetId = curl -L `
@@ -116,7 +139,7 @@ jobs:
           --data-binary "@childdebugger-win32-x64.vsix" `
           "https://uploads.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets?name=childdebugger-win32-x64.vsix"
 
-      - name: Upload release asset (tests)
+      - name: Upload release asset (tests, x64)
         shell: pwsh
         run: |
           $assetId = curl -L `
@@ -145,7 +168,7 @@ jobs:
           --data-binary "@childdebugger-win32-x64-tests.zip" `
           "https://uploads.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets?name=childdebugger-win32-x64-tests.zip"
 
-      - name: Upload release asset (debug-sybols)
+      - name: Upload release asset (debug-symbols, x64)
         shell: pwsh
         run: |
           $assetId = curl -L `
@@ -173,6 +196,93 @@ jobs:
           -H "Content-Type: application/zip" `
           --data-binary "@childdebugger-win32-x64-debug-symbols.zip" `
           "https://uploads.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets?name=childdebugger-win32-x64-debug-symbols.zip"
+
+      - name: Upload release asset (vsix, arm64)
+        shell: pwsh
+        run: |
+          $assetId = curl -L `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          https://api.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets | `
+          ConvertFrom-Json | `
+          Where-Object -Property name -Value "childdebugger-win32-arm64.vsix" -EQ | `
+          Select-Object -Expand id
+
+          if($assetId) {
+            curl -L `
+            -X DELETE `
+            -H "Accept: application/vnd.github+json" `
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"`
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            https://api.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/assets/$assetId
+          }
+
+          curl -i -X POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          -H "Content-Type: application/zip" `
+          --data-binary "@childdebugger-win32-arm64.vsix" `
+          "https://uploads.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets?name=childdebugger-win32-arm64.vsix"
+
+      - name: Upload release asset (tests, arm64)
+        shell: pwsh
+        run: |
+          $assetId = curl -L `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          https://api.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets | `
+          ConvertFrom-Json | `
+          Where-Object -Property name -Value "childdebugger-win32-arm64-tests.zip" -EQ | `
+          Select-Object -Expand id
+
+          if($assetId) {
+            curl -L `
+            -X DELETE `
+            -H "Accept: application/vnd.github+json" `
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"`
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            https://api.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/assets/$assetId
+          }
+
+          curl -i -X POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          -H "Content-Type: application/zip" `
+          --data-binary "@childdebugger-win32-arm64-tests.zip" `
+          "https://uploads.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets?name=childdebugger-win32-arm64-tests.zip"
+
+      - name: Upload release asset (debug-symbols, arm64)
+        shell: pwsh
+        run: |
+          $assetId = curl -L `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          https://api.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets | `
+          ConvertFrom-Json | `
+          Where-Object -Property name -Value "childdebugger-win32-arm64-debug-symbols.zip" -EQ | `
+          Select-Object -Expand id
+
+          if($assetId) {
+            curl -L `
+            -X DELETE `
+            -H "Accept: application/vnd.github+json" `
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"`
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            https://api.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/assets/$assetId
+          }
+
+          curl -i -X POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          -H "Content-Type: application/zip" `
+          --data-binary "@childdebugger-win32-arm64-debug-symbols.zip" `
+          "https://uploads.github.com/repos/albertziegenhagel/childdebugger-vscode/releases/126145941/assets?name=childdebugger-win32-arm64-debug-symbols.zip"
 
   publish:
     name: "Puplish"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,22 @@ permissions:
 
 jobs:
   package:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.run-on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        run-on: [windows-latest, windows-11-arm]
+        node-version: [any]
+        include:
+          - run-on: windows-latest
+            node-version: 18.17
+            arch: x64
+          - run-on: windows-11-arm
+            node-version: 20
+            arch: arm64
+        exclude:
+          - node-version: any
 
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.17
+          node-version: ${{ matrix.node-version }}
 
       - name: Install VSCE
         run: npm install -g @vscode/vsce
@@ -44,6 +59,29 @@ jobs:
           nuget install Microsoft.VSSDK.Debugger.VSDebugEng -Version 17.0.2012801
           nuget install Microsoft.VSSDK.Debugger.VSDConfigTool -Version 17.0.2012801
   
+      - uses: TheMrMilchmann/setup-msvc-dev@v3
+        if: matrix.run-on == 'windows-11-arm'
+        with:
+          arch: arm64
+
+      - name: Configure VSDbg Engine Extension (arm64)
+        if: matrix.run-on == 'windows-11-arm'
+        run: |
+          mkdir build/arm64
+          cd build/arm64
+          cmake "${{ github.workspace }}\vsdbg-engine-extension" `
+          -G Ninja `
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+          -DCMAKE_PREFIX_PATH="${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDebugEng.17.0.2012801\build\native;${{ github.workspace }}\Microsoft.VSSDK.Debugger.VSDConfigTool.17.0.2012801\build" `
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}\vsdbg-engine-extension" `
+          -DCHILDDEBUGGER_INSTALL_PDB=ON
+
+      - name: Build & Install VSDbg Engine Extension (arm64)
+        if: matrix.run-on == 'windows-11-arm'
+        run: |
+          cd build/arm64
+          ninja install
+
       - uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
           arch: x64
@@ -92,20 +130,24 @@ jobs:
 
       - name: Package VSIX
         run: |
-          vsce package --target win32-x64 --pre-release
-          mv childdebugger-win32-x64-*.vsix childdebugger-win32-x64.vsix
+          vsce package --target win32-${{ matrix.arch }} --pre-release
+          mv childdebugger-win32-${{ matrix.arch }}-*.vsix childdebugger-win32-${{ matrix.arch }}.vsix
 
       - name: Upload extension VSIX
         uses: actions/upload-artifact@v4
         with: 
-          name: childdebugger-win32-x64
+          name: childdebugger-win32-${{ matrix.arch }}
           path: ${{ github.workspace }}/*.vsix
 
       - name: Upload test binaries
         uses: actions/upload-artifact@v4
         with:
-          name: childdebugger-win32-x64-tests
+          name: childdebugger-win32-${{ matrix.arch }}-tests
           path: |
+            ${{ github.workspace }}/vsdbg-engine-extension/bin/tests/arm64/caller.exe
+            ${{ github.workspace }}/vsdbg-engine-extension/bin/tests/arm64/caller.pdb
+            ${{ github.workspace }}/vsdbg-engine-extension/bin/tests/arm64/callee.exe
+            ${{ github.workspace }}/vsdbg-engine-extension/bin/tests/arm64/callee.pdb
             ${{ github.workspace }}/vsdbg-engine-extension/bin/tests/x64/caller.exe
             ${{ github.workspace }}/vsdbg-engine-extension/bin/tests/x64/caller.pdb
             ${{ github.workspace }}/vsdbg-engine-extension/bin/tests/x64/callee.exe
@@ -119,8 +161,9 @@ jobs:
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
-          name: childdebugger-win32-x64-debug-symbols
+          name: childdebugger-win32-${{ matrix.arch }}-debug-symbols
           path: |
+            ${{ github.workspace }}/vsdbg-engine-extension/bin/arm64/ChildDebugger.pdb
             ${{ github.workspace }}/vsdbg-engine-extension/bin/x64/ChildDebugger.pdb
             ${{ github.workspace }}/vsdbg-engine-extension/bin/x86/ChildDebugger.pdb
             ${{ github.workspace }}/vsdbg-engine-extension/bin/info.txt

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -17,14 +17,19 @@ async function main() {
 		const [cliPath, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
 		// Use cp.spawn / cp.exec for custom setup
-		cp.spawnSync(
+		console.info('Install dependencies:');
+		console.info(`  ${cliPath} ${args}`);
+		const result = cp.spawnSync(
 			cliPath,
 			[...args, '--install-extension', 'ms-vscode.cpptools'],
 			{
-				encoding: 'utf-8',
-				stdio: 'inherit'
+				shell: true
 			}
 		);
+		console.info(`  status: ${result.status}`);
+		console.info(`  stdout: ${result.stdout}`);
+		console.info(`  stderr: ${result.stderr}`);
+		console.info(`  error:  ${result.error}`);
 
 		// Download VS Code, unzip it and run the integration test
 		await runTests({ extensionDevelopmentPath, extensionTestsPath });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -114,7 +114,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`No attach (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN No attach (${arch}).`);
@@ -137,7 +137,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions.length, 1);
 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Disabled attach (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Disabled attach (${arch}).`);
@@ -161,7 +161,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 		assert.strictEqual(result.startedSessions.length, 1);
 
 		assert.strictEqual(result.startedSessions[0].name, "Parent Session");
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach non existent (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN non existent (${arch}).`);
@@ -189,7 +189,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 
 		assert.include(result.output, "failed to create child process");
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach recursive (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach recursive (${arch}).`);
@@ -267,7 +267,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid1}, ${ptid1}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach suspended (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach suspended (${arch}).`);
@@ -320,7 +320,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach multi-threaded (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach multi-threaded (${arch}).`);
@@ -394,7 +394,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`CALLEE (${cpid2}, ${ctid2}): terminating`,
 			`CALLER (${ppid2}, ${ptid2}): terminating thread`
 		]);
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach only command line (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach Only Command Line (${arch}).`);
@@ -445,7 +445,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach once ANSI (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach ANSI (${arch}).`);
@@ -496,7 +496,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach only command line ANSI (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach Only Command Line ANSI (${arch}).`);
@@ -548,7 +548,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach once User (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach user (${arch}).`);
@@ -599,7 +599,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	test(`Attach once User ANSI (${arch})`, async () => {
 		vscode.window.showInformationMessage(`RUN Attach user ANSI (${arch}).`);
@@ -651,7 +651,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 			`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 		);
 
-	}).timeout(100000);
+	}).timeout(400000);
 
 	if (process.env.CHILDDEBUGGER_TEST_IS_ADMIN === "1") {
 
@@ -704,7 +704,7 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 				`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 			);
 
-		}).timeout(100000);
+		}).timeout(400000);
 
 		if (process.env.CHILDDEBUGGER_TEST_HAS_TEST_USER === "1") {
 
@@ -759,11 +759,24 @@ function testArchitecture(callerPath: string, calleePath: string, arch: string) 
 					`  CALLER (${ppid}, ${ptid}): terminating thread\r\n`
 				);
 
-			}).timeout(100000);
+			}).timeout(400000);
 		}
 	}
 
 }
+
+suite('Auto attach arm64', () => {
+	if (process.arch !== 'arm64') {
+		return;
+	}
+
+	const testExeDirArm64 = path.join(__dirname, "..", "..", "..", "vsdbg-engine-extension", "bin", "tests", "arm64");
+
+	const callerPathArm64 = path.join(testExeDirArm64, "caller.exe");
+	const calleePathArm64 = path.join(testExeDirArm64, "callee.exe");
+
+	testArchitecture(callerPathArm64, calleePathArm64, "arm64");
+});
 
 suite('Auto attach x64', () => {
 	const testExeDirX64 = path.join(__dirname, "..", "..", "..", "vsdbg-engine-extension", "bin", "tests", "x64");
@@ -775,6 +788,10 @@ suite('Auto attach x64', () => {
 });
 
 suite('Auto attach x86', () => {
+	if (process.arch === 'arm64') {
+		return;
+	}
+
 	const testExeDirX86 = path.join(__dirname, "..", "..", "..", "vsdbg-engine-extension", "bin", "tests", "x86");
 
 	const callerPathX86 = path.join(testExeDirX86, "caller.exe");


### PR DESCRIPTION
Now that GitHub provides Windows ARM64 runners, we can enable building and testing the ARM version.

Currently, we only build the VSIX, test executables etc, but they will not be published to official releases on the VS Code Marketplace, since I did not have a chance to test the ARM version manually.