### PR TITLE
Copy logging and symbol configurations from parent to child debug sessions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,9 +130,11 @@ export function activate(context: vscode.ExtensionContext) {
 						_childDebuggerExtension: configurationExtension,
 						// always attach to children of children
 						autoAttachChildProcess: true,
+						logging: session.configuration.logging,
+						symbolOptions: session.configuration.symbolOptions,
+						symbolSearchPath: session.configuration.symbolSearchPath,
 						visualizerFile: session.configuration.visualizerFile,
-						// TODO: should we copy other configuration properties (like `symbolOptions`)
-						//       from the parent to the child?,
+						// TODO: Copy other relevant debug configurations from the parent debug session to the child
 					};
 					const options: vscode.DebugSessionOptions = {
 						parentSession: session,


### PR DESCRIPTION
Relates to #38

I use your extension on a daily basis and was having issues with loading symbols on child sessions, looks like this is already mapped by #38 so I figured I should open a PR with the minimum changes required to copy the logging and symbol configurations, please suggest changes if you think this is insufficient for merge.

Alternatively, I also saw that you've mentioned that you're trying to find time to fix #38, please close this if you have already started working on the fix.